### PR TITLE
feat(commons): create initial commons package directory and README.md

### DIFF
--- a/packages/commons/README.md
+++ b/packages/commons/README.md
@@ -1,0 +1,30 @@
+# Deque.AxeCore.Commons
+
+Provides a .NET wrapper around [axe-core](https://github.com/dequelabs/axe-core), including a bundled copy of `axe-core` and .NET typings for its options and results.
+
+## Getting Started
+
+*Note: this package is still under development; these instructions won't work until we perform an initial NuGet release*
+
+Install a [.NET SDK](https://dotnet.microsoft.com/download) if you haven't already.
+
+Install `Deque.AxeCore.Commons` and its dependencies:
+
+```console
+dotnet add package Deque.AxeCore.Commons
+```
+
+## Usage
+
+This package exists primarily to help .NET tool developers integrate `axe-core` with different tools and test frameworks. If you are just trying to write test cases using `axe-core`, you probably want to use one of these instead:
+
+* [Deque.AxeCore.Playwright](../playwright/README.md) in combination with [Playwright for .NET](https://playwright.dev/dotnet/)
+* [Deque.AxeCore.Selenium](../selenium/README.md) in combination with [Selenium](https://www.selenium.dev/)'s [C# Selenium.WebDriver package](https://www.nuget.org/packages/Selenium.WebDriver)
+
+## License
+
+This package, including its embedded copy of [axe-core][axe-core], is distributed under the terms of the [Mozilla Public License, version 2.0](../../LICENSE-Deque.AxeCore.Commons.txt).
+
+## Acknowledgements
+
+This package builds on past work from the [SeleniumAxeDotnet](https://github.com/TroyWalshProf/SeleniumAxeDotnet) and [PlaywrightAxeDotnet](https://github.com/IsaacWalker/PlaywrightAxeDotnet) projects (see [NOTICE.txt](../../NOTICE.txt)). We thank all of those projects' contributors for their work.


### PR DESCRIPTION
This PR initializes the `/packages/commons` directory that will contain the `Deque.AxeCore.Commons` package with a skeleton `README.md` file.

Part of #7 