### PR TITLE
(feat: change-log-contributing): Adding stubs for the Contributing and Change Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
 # Change Log
 
 All notable changes to this project will be documented in this file moving forward. Reference [Conventional Commits](https://conventionalcommits.org/) for commit guidelines. 
-
-# Contribution Guidelines
-Pull Requests should have a title that starts with a tag indicating the type of change. This helps us in maintaining a good commit history as well as better documentation when creating Release notes.
-
-The convention that we follow is inspired from [SemVer](https://semver.org/) convention:
-
-| Tag      | What it conveys                                                                                                                             |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| feat     | a commit of the type feat introduces a new feature in main or means completion of task towards a feature                                  |
-| fix      | a commit of the type fix patches a bug or fixes a small known problem                                                                       |
-| chore    | a commit of the type chore updates something in codebase without impacting any production code. eg: updating a grunt task etc.              |
-| refactor | a commit of type refactor specifies a code change that neither fixes a bug nor adds a feature but just refactors a portion of existing code |
-| chore | a commit of type chore references a code change to the build process or auxiliary tools and libraries such as documentation generation |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file moving forward. Reference [Conventional Commits](https://conventionalcommits.org/) for commit guidelines. 
+
+# Contribution Guidelines
+Pull Requests should have a title that starts with a tag indicating the type of change. This helps us in maintaining a good commit history as well as better documentation when creating Release notes.
+
+The convention that we follow is inspired from [SemVer](https://semver.org/) convention:
+
+| Tag      | What it conveys                                                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| feat     | a commit of the type feat introduces a new feature in main or means completion of task towards a feature                                  |
+| fix      | a commit of the type fix patches a bug or fixes a small known problem                                                                       |
+| chore    | a commit of the type chore updates something in codebase without impacting any production code. eg: updating a grunt task etc.              |
+| refactor | a commit of type refactor specifies a code change that neither fixes a bug nor adds a feature but just refactors a portion of existing code |
+| chore | a commit of type chore references a code change to the build process or auxiliary tools and libraries such as documentation generation |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,16 @@
 # Contributing
 
 In order to contribute, you must accept the [contributor license agreement](https://cla.microsoft.com/), indicating that you consent to our use of your contribution. 
+
+# Contribution Guidelines
+Pull Requests should have a title that starts with a tag indicating the type of change. This helps us in maintaining a good commit history as well as better documentation when creating Release notes.
+
+The convention that we follow is inspired from [SemVer](https://semver.org/) convention:
+
+| Tag      | What it conveys                                                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| feat     | a commit of the type feat introduces a new feature in main or means completion of task towards a feature                                  |
+| fix      | a commit of the type fix patches a bug or fixes a small known problem                                                                       |
+| chore    | a commit of the type chore updates something in codebase without impacting any production code. eg: updating a grunt task etc.              |
+| refactor | a commit of type refactor specifies a code change that neither fixes a bug nor adds a feature but just refactors a portion of existing code |
+| chore | a commit of type chore references a code change to the build process or auxiliary tools and libraries such as documentation generation |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,23 @@
 # Contributing
 
-In order to contribute, you must accept the [contributor license agreement](https://cla.microsoft.com/), indicating that you consent to our use of your contribution. 
+## Contributor License Agreement
 
-# Contribution Guidelines
-Pull Requests should have a title that starts with a tag indicating the type of change. This helps us in maintaining a good commit history as well as better documentation when creating Release notes.
+In order to contribute, you must accept the [contributor license agreement](https://cla-assistant.io/dequelabs/axe-core-nuget), indicating that you consent to our use of your contribution. 
 
-The convention that we follow is inspired from [SemVer](https://semver.org/) convention:
+## Contribution Guidelines
+For code contributions, we recommend reviewing the following docs from the axe-core repo:
+1. [Code submission guidelines](https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md) 
+2. [CONTRIBUTING.md](https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md) 
 
-| Tag      | What it conveys                                                                                                                             |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| feat     | a commit of the type feat introduces a new feature in main or means completion of task towards a feature                                  |
-| fix      | a commit of the type fix patches a bug or fixes a small known problem                                                                       |
-| chore    | a commit of the type chore updates something in codebase without impacting any production code. eg: updating a grunt task etc.              |
-| refactor | a commit of type refactor specifies a code change that neither fixes a bug nor adds a feature but just refactors a portion of existing code |
-| chore | a commit of type chore references a code change to the build process or auxiliary tools and libraries such as documentation generation |
+This documentation covers a variety of important information you'll need to review before making code changes, including our commitment to code quality, preferred commit structure, and relevant pull request formatting and processes. 
+
+### Code Quality
+Although we do not have official code style guidelines, we can and will request you to make changes if we feel the changes are warranted. You can take clues from the existing code base to see what we consider to be reasonable code quality. Please be prepared to make changes that we ask of you even if you might not agree with the request(s).
+
+Please respect the coding style of the files you are changing and adhere to that.
+
+The files in this project are formatted by using the `dotnet format` command
+
+### Testing
+
+We expect all code to be 100% covered by tests. We don't have or want code coverage metrics but we will review tests and suggest changes when we think the test(s) do(es) not adequately exercise the code/code changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+In order to contribute, you must accept the [contributor license agreement](https://cla.microsoft.com/), indicating that you consent to our use of your contribution. 


### PR DESCRIPTION
This PR adds the `CONTRIBUTING.md` and `CHANGELOG.md` files to the repo and continues with the partial implementation of #7 