### PR TITLE
feat(selenium): add reference from selenium project to commons project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 src/resources/standards
 dist-docs
 .DS_Store
+.vs/
 coverage*.xml
 coverage*.json
 coveragereport

--- a/Deque.AxeCore.sln
+++ b/Deque.AxeCore.sln
@@ -8,6 +8,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Commons", "pa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Commons.Test", "packages\commons\test\Deque.AxeCore.Commons.Test.csproj", "{F06315BB-0847-4A20-AEF4-6FB3A46016A7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "selenium", "selenium", "{7273D75C-DB83-4C12-B48D-7C575A8DEBC7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Selenium", "packages\selenium\src\Deque.AxeCore.Selenium.csproj", "{598B6BDA-8082-4119-A755-970D72A4B64C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Selenium.Test", "packages\selenium\test\Deque.AxeCore.Selenium.Test.csproj", "{7D5DB0A8-263E-40D4-90C8-B86BA672C783}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,9 +31,19 @@ Global
 		{F06315BB-0847-4A20-AEF4-6FB3A46016A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F06315BB-0847-4A20-AEF4-6FB3A46016A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F06315BB-0847-4A20-AEF4-6FB3A46016A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{598B6BDA-8082-4119-A755-970D72A4B64C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{598B6BDA-8082-4119-A755-970D72A4B64C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{598B6BDA-8082-4119-A755-970D72A4B64C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{598B6BDA-8082-4119-A755-970D72A4B64C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D5DB0A8-263E-40D4-90C8-B86BA672C783}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D5DB0A8-263E-40D4-90C8-B86BA672C783}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D5DB0A8-263E-40D4-90C8-B86BA672C783}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D5DB0A8-263E-40D4-90C8-B86BA672C783}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{05A828D4-ED6F-4C8E-8D7C-62B84E3C359E} = {503C1F96-0BAB-457A-AC0F-F8E596F3ADD6}
 		{F06315BB-0847-4A20-AEF4-6FB3A46016A7} = {503C1F96-0BAB-457A-AC0F-F8E596F3ADD6}
+		{598B6BDA-8082-4119-A755-970D72A4B64C} = {7273D75C-DB83-4C12-B48D-7C575A8DEBC7}
+		{7D5DB0A8-263E-40D4-90C8-B86BA672C783} = {7273D75C-DB83-4C12-B48D-7C575A8DEBC7}
 	EndGlobalSection
 EndGlobal

--- a/packages/selenium/src/AxeBuilderOptions.cs
+++ b/packages/selenium/src/AxeBuilderOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Deque.AxeCore.Selenium
+﻿using Deque.AxeCore.Commons;
+
+namespace Deque.AxeCore.Selenium
 {
     public class AxeBuilderOptions
     {

--- a/packages/selenium/src/Deque.AxeCore.Selenium.csproj
+++ b/packages/selenium/src/Deque.AxeCore.Selenium.csproj
@@ -35,6 +35,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.4.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../commons/src/Deque.AxeCore.Commons.csproj" />
+  </ItemGroup>
   
   <!-- Running this using BeforeTagets="Restore" doesn't work if we run "dotnet restore" from solution folder. 
        Running it before CollectPackageReferences, will work in both vs & command line. But, this task will be executed in both build & restore multiple times on multi-target project.

--- a/packages/selenium/src/EmbeddedResourceAxeProvider.cs
+++ b/packages/selenium/src/EmbeddedResourceAxeProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace Deque.AxeCore.Selenium
+﻿using Deque.AxeCore.Commons;
+
+namespace Deque.AxeCore.Selenium
 {
     internal class EmbeddedResourceAxeProvider : IAxeScriptProvider
     {

--- a/packages/selenium/src/ExternalAxeScriptProvider.cs
+++ b/packages/selenium/src/ExternalAxeScriptProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Deque.AxeCore.Commons;
+using System;
 using System.Net;
 
 namespace Deque.AxeCore.Selenium

--- a/packages/selenium/src/FileAxeScriptProvider.cs
+++ b/packages/selenium/src/FileAxeScriptProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Deque.AxeCore.Commons;
+using System;
 using System.IO;
 
 namespace Deque.AxeCore.Selenium

--- a/packages/selenium/src/IAxeScriptProvider.cs
+++ b/packages/selenium/src/IAxeScriptProvider.cs
@@ -1,7 +1,0 @@
-﻿namespace Deque.AxeCore.Selenium
-{
-    public interface IAxeScriptProvider
-    {
-        string GetScript();
-    }
-}

--- a/packages/selenium/src/WebDriverInjectorExtensions.cs
+++ b/packages/selenium/src/WebDriverInjectorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using OpenQA.Selenium;
+﻿using Deque.AxeCore.Commons;
+using OpenQA.Selenium;
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
This PR wires up the selenium project to make use of the commons project. It includes:

* Adds a project reference from selenium csproj to commons
* Updates the selenium code to use a single type from commons (`IAxeScriptProvider`) instead of itself to verify that the wiring is working correctly
* Adds the selenium project (and its test project) to the repo-level sln file
  * When I tested that this opened reasonably in Visual Studio, I found that `.gitignore` was missing an entry for the `.vs/` folder that Visual Studio uses for temp files, so I added that while I was here

To verify, run `dotnet test` from the root of the repo - it should pick up all 4 projects and successfully run 6 instances of tests (3x target framework for each of the 2 test projects)

Out of scope (to be handled in other PRs):
* Migrating axe-core embed logic
* Migrating typings

Part of issue #13 