### PR TITLE
ci: add publish/release workflows in dry-run mode

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,12 +6,12 @@ on:
     inputs:
       configuration:
         description: "debug or release (for use with dotnet CLI's -c argument)"
-        required: true
         type: string
+        default: release
       version-suffix:
-        description: "Version suffix (eg, for a version of 1.2.3-alpha.1, pass, \"-alpha.1\")"
-        required: true
+        description: "Version suffix (eg, for a version of 1.2.3-alpha.1, pass \"alpha.1\")"
         type: string
+        default: "development.${{ github.sha }}"
 
 jobs:
   build-and-test:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,61 @@
+name: Create release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseLevel:
+        description: 'Release level: major, minor, or patch.'
+        required: true
+        default: 'patch'
+
+jobs:
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Run preparation script
+        run: bash .github/scripts/prepare_release.sh ${{ github.event.inputs.releaseLevel }}
+        env:
+          CHANGELOG_VERSION: ${{ secrets.CHANGELOG_VERSION }}
+          COMMIT_AND_TAG_VERSION_VERSION: ${{ secrets.COMMIT_AND_TAG_VERSION_VERSION }}
+
+      - name: Get version for later steps
+        id: get-new-version
+        run: echo ::set-output name=version::$(node -pe 'require("./package.json").version')
+
+      - name: Create release commit
+        run: |
+          git config user.name "${{ secrets.ADT_API_RELEASE_NAME}}"
+          git config user.email "${{ secrets.ADT_API_RELEASE_EMAIL }}"
+          git commit -am "chore: release v${{ steps.get-new-version.outputs.version }}"
+
+      # create-pull-request has no way of setting the target branch that won't also
+      # get rid of all commits (aside from the release commit).
+      # So, we have to be on master and manually grab all the changes.
+      # We do that by just telling git "master is now develop (+ the release commit)".
+      - name: Update local master from develop
+        run: |
+          commitHash="$(git log -1 --format='%H')"
+          git checkout master
+          git reset --hard "$commitHash"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release
+          branch-suffix: timestamp
+          base: master
+          title: "chore: release v${{ steps.get-new-version.outputs.version }}"
+          # If there are any changes not already committed, they will be added to
+          # a commit with this as the message.
+          # If there are no changes no commit will be created.
+          commit-message: "chore: applying release changes"

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -14,9 +14,8 @@ jobs:
       version-suffix: "alpha.${{ github.run_number }}"
 
   publish-nuget:
-    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
-    environment: nuget-canary
-    needs: ["build-and-test"]
     uses: ./.github/workflows/publish-nuget-packages.yml
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    needs: ["build-and-test"]
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - develop
-      # TODO: remove this before un-drafting PR
-      - 'release-workflow-testing/mock-develop'
 
 jobs:
   build-and-test:
@@ -15,8 +13,7 @@ jobs:
 
   publish-nuget:
     uses: ./.github/workflows/publish-nuget-packages.yml
-    # TODO: restore this before un-drafting PR
-    # if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["build-and-test"]
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,22 @@
+name: Publish canary
+
+on:
+  push:
+    branches:
+      - develop
+      # TODO: remove this before un-drafting PR
+      - 'release-workflow-testing/mock-develop'
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    with:
+      version-suffix: "alpha.${{ github.run_number }}"
+
+  publish-nuget:
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    environment: nuget-canary
+    needs: ["build-and-test"]
+    uses: ./.github/workflows/publish-nuget-packages.yml
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -15,7 +15,8 @@ jobs:
 
   publish-nuget:
     uses: ./.github/workflows/publish-nuget-packages.yml
-    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    # TODO: restore this before un-drafting PR
+    # if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["build-and-test"]
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -1,0 +1,43 @@
+name: Publish NuGet packages
+
+on:
+  # This is a reusable workflow, not intended to be invoked directly
+  workflow_call:
+    inputs:
+      packages-artifact-name:
+        description: "Name of a previously-uploaded artifact containing a flat collection of .nupkg files to publish"
+        default: packages # matches what ./build-and-test.yml produces
+        type: string
+    secrets:
+      NUGET_API_KEY:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.x.x
+
+      - name: Download packages artifact from build-and-test job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.packages-artifact-name }}
+          path: ${{ github.workspace }}/packages
+
+      - name: List packages to be published
+        run: ls packages
+
+      # Order is important - if publishing Commons fails, we want the job to abort without attempting the others
+      #
+      # TODO: drop the "echo [DRY RUN]" prefix being used for dry-run testing
+      - name: Publish Deque.AxeCore.Commons to NuGet
+        run: echo '[DRY RUN] dotnet nuget push packages/Deque.AxeCore.Commons.*.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json'
+
+      - name: Publish Deque.AxeCore.Selenium to NuGet
+        run: echo '[DRY RUN] dotnet nuget push packages/Deque.AxeCore.Selenium.*.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json'
+      
+      - name: Publish Deque.AxeCore.Playwright to NuGet
+        run: echo '[DRY RUN] dotnet nuget push packages/Deque.AxeCore.Playwright.*.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json'

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Order is important - if publishing Commons fails, we want the job to abort without attempting the others
       #
-      # TODO: drop the "echo [DRY RUN]" prefix being used for dry-run testing
+      # TODO: drop the "echo [DRY RUN]" wrapper once the NuGet publishing account is established in #38
       - name: Publish Deque.AxeCore.Commons to NuGet
         run: echo '[DRY RUN] dotnet nuget push packages/Deque.AxeCore.Commons.*.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json'
 

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - run: go get gopkg.in/aktau/github-release.v0
+      - name: Install github-release tool
+        run: go install gopkg.in/aktau/github-release.v0@v0.10.0
 
       - name: Download and run GitHub release script
         run: |

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -1,0 +1,45 @@
+name: Publish production
+
+on:
+  push:
+    branches:
+      - master
+      # TODO: remove this before un-drafting PR
+      - 'release-workflow-testing/mock-master'
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    with:
+      version-suffix: ""
+
+  publish-nuget:
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    environment: nuget-production
+    needs: ["build-and-test"]
+    uses: ./.github/workflows/publish-nuget-packages.yml
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  publish-github-release:
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    environment: github-releases
+    needs: ["publish-nuget"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # this permission controls release creation
+    steps:     
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - run: go get gopkg.in/aktau/github-release.v0
+
+      - name: Download and run GitHub release script
+        run: |
+          curl https://raw.githubusercontent.com/dequelabs/attest-release-scripts/develop/src/node-github-release.sh -s -o ./node-github-release.sh
+          chmod +x ./node-github-release.sh
+          ./node-github-release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CIRCLE_PROJECT_USERNAME: ${{ github.repository_owner }}
+          CIRCLE_PROJECT_REPONAME: ${{ github.event.repository.name }}

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -15,13 +15,15 @@ jobs:
 
   publish-nuget:
     uses: ./.github/workflows/publish-nuget-packages.yml
-    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    # TODO: restore this before un-drafting PR
+    # if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["build-and-test"]
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   publish-github-release:
-    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    # TODO: restore this before un-drafting PR
+    # if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["publish-nuget"]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      # TODO: remove this before un-drafting PR
-      - 'release-workflow-testing/mock-master'
 
 jobs:
   build-and-test:
@@ -15,15 +13,13 @@ jobs:
 
   publish-nuget:
     uses: ./.github/workflows/publish-nuget-packages.yml
-    # TODO: restore this before un-drafting PR
-    # if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["build-and-test"]
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   publish-github-release:
-    # TODO: restore this before un-drafting PR
-    # if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["publish-nuget"]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19.0'
+
       - name: Install github-release tool
         run: go install gopkg.in/aktau/github-release.v0@v0.10.0
 

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -14,16 +14,14 @@ jobs:
       version-suffix: ""
 
   publish-nuget:
-    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
-    environment: nuget-production
-    needs: ["build-and-test"]
     uses: ./.github/workflows/publish-nuget-packages.yml
+    if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
+    needs: ["build-and-test"]
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   publish-github-release:
     if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
-    environment: github-releases
     needs: ["publish-nuget"]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,11 +1,6 @@
 name: PR checks
-
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml
-    with:
-      configuration: debug
-      version-suffix: "-development.${{ github.sha }}"

--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -1,0 +1,20 @@
+name: Sync master/develop branches
+on:
+  pull_request:
+    types: [closed]
+    branches: master
+
+jobs:
+  create_sync_pull_request:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.event.pull_request.merged == 'true'
+    steps:
+      - uses: dequelabs/action-sync-branches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-title: "chore: merge master into develop"
+          pr-reviewers: AdnoC,michael-siek
+          pr-labels: chore
+          pr-template: .github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
This PR implements the second half of what was originally #34. It is modeled after the workflows in https://github.com/dequelabs/axe-core-maven-html, https://github.com/dequelabs/axe-core-npm, https://github.com/dequelabs/axe-core, and off discussion with @AdnoC about how certain internal Deque .NET builds work.

For now, the final `dotnet nuget push` steps that do the literal publishing to nuget are implemented in "dry run" mode, since there isn't a NuGet account established yet to do the actual release. Once that's done (tracked by #38), the end of `publish-nuget-packages.yml` should be updated accordingly.

It is intended to work very similarly to existing build/release automation in the other similar libraries, except with everything based on GitHub actions instead of going through CircleCI. Specifically:

* The source of truth for the currently released version is a stub `/package.json` file (the version number is repeated in each non-test `.csproj`)
* Each PR will run build/checks/tests in a debug configuration (`pull-request.yml`) and produce packages for debugging purposes with version numbers like `1.2.3-development.f4aeb4fa83661e5a5b612abb25997c379919bbde`
* Each push to develop (usually PR merge commits) will kick off the `publish-canary.yml` workflow, which repeats the build/tests in a release configuration, produces `.nupkg` artifacts for each library, and publishes them as pre-release NuGet versions with a version number like `1.2.3-alpha.1`, where the final number comes from [`github.run_number`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).
* Production releases are kicked off by a human manually scheduling a `create-release.yml` workflow, which automates the creation of a PR from `develop` to `master` which uses `commit-and-tag-version` and `conventional-changelog-cli` to update version numbers and CHANGELOG.md appropriately.
* Each push to master (a PR merge commit of a PR created by `create-release.yml`) will kick off the `publish-production.yml` workflow, which works similarly to `publish-canary` except using a version number without a suffix (like `1.2.3`) and which includes an additional `publish-github-release` job based on the similar circleci implementation from the example repos
* Closed PRs to master will also trigger the `sync-master-develop.yml` workflow to resync develop with the version update applied to master. This workflow is copied from the examples, with the pr reviewers changed to @AdnoC and @michael-siek 

The assorted release builds will require the following secrets be added to the repo:

* `CHANGELOG_VERSION`: same as in example repos (used by `create-release.yml`, should be a version number of the `conventional-changelog-cli` npm package)
* `COMMIT_AND_TAG_VERSION_VERSION`: new, similar to `SEMANTIC_VERSION_VERSION` in example repos (used by `create-release.yml`, should be a version number of the `commit-and-tag-version` npm package
* `ADT_API_RELEASE_NAME`: same as in example repos (used by `create-release.yml`, will be the committer name for release commits)
* `ADT_API_RELEASE_EMAIL`: same as in example repos (used by `create-release.yml`, will be the committer email for release commits)
* `NUGET_API_KEY`: (tracked by #38) new, should be a [NuGet API key](https://docs.microsoft.com/en-us/nuget/nuget-org/scoped-api-keys) with scoped permissions to publish new versions of the 3 specific packages in question. Used by all `publish-*` workflows.
  * For initial testing of these release workflows, recommend leaving this unset or set to an invalid value for initial dry runs
  * For doing an initial publish, this can be a key that also has permissions to publish new packages, or someone can manually upload the initial versions

Once this is merged and working, we should enable corresponding branch protection policies for develop and master.

Demos of the workflows in action:

* [publish-canary dry run](https://github.com/dbjorge/axe-core-nuget/actions/runs/2936032353)
* [publish-production dry run](https://github.com/dbjorge/axe-core-nuget/actions/runs/2936228606)
* [example GitHub release produced by publish-production](https://github.com/dbjorge/axe-core-nuget/releases/tag/v4.4.0)

Closes Issue: #10