### PR TITLE
test: standardize test projects on nunit with consistent output formats

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,15 +51,6 @@ jobs:
           name: test-results
           path: |
             ${{ github.workspace }}/packages/*/test/TestResults
-            !${{ github.workspace }}/packages/*/test/TestResults/**/verbose-logs
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() && steps.test.outcome == 'failure' }}
-        name: Upload test-verbose-logs artifact if tests failed
-        with:
-          name: test-results
-          path: |
-            ${{ github.workspace }}/packages/*/test/TestResults/**/verbose-logs
       
       - name: Prepare packages artifact
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,7 @@ jobs:
         run: dotnet build --no-restore -c ${{ inputs.configuration }} -p:VersionSuffix=${{ inputs.version-suffix }}
       
       - name: Test
+        id: test
         run: |
           dotnet test --no-build -c ${{ inputs.configuration }} -p:VersionSuffix=${{ inputs.version-suffix }} \
             --logger GitHubActions --logger trx --logger html --logger "console;verbosity=minimal"
@@ -50,6 +51,15 @@ jobs:
           name: test-results
           path: |
             ${{ github.workspace }}/packages/*/test/TestResults
+            !${{ github.workspace }}/packages/*/test/TestResults/**/verbose-logs
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() && steps.test.outcome == 'failure' }}
+        name: Upload test-verbose-logs artifact if tests failed
+        with:
+          name: test-results
+          path: |
+            ${{ github.workspace }}/packages/*/test/TestResults/**/verbose-logs
       
       - name: Prepare packages artifact
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,9 @@ jobs:
         run: dotnet build --no-restore -c ${{ inputs.configuration }} -p:VersionSuffix=${{ inputs.version-suffix }}
       
       - name: Test
-        run: dotnet test --no-build -c ${{ inputs.configuration }} -p:VersionSuffix=${{ inputs.version-suffix }}
+        run: |
+          dotnet test --no-build -c ${{ inputs.configuration }} -p:VersionSuffix=${{ inputs.version-suffix }} \
+            --logger GitHubActions --logger trx --logger html --logger "console;verbosity=minimal"
 
       - uses: actions/upload-artifact@v2
         if: ${{ success() || failure() }}

--- a/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
+++ b/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
@@ -21,4 +25,8 @@
   <ItemGroup>
     <ProjectReference Include="..\src\Deque.AxeCore.Commons.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <VSTestResultsDirectory>TestResults/$(TargetFramework)</VSTestResultsDirectory>
+	</PropertyGroup>
 </Project>

--- a/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
+++ b/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/packages/playwright/test/AxeContentEmbedderTests.cs
+++ b/packages/playwright/test/AxeContentEmbedderTests.cs
@@ -2,20 +2,21 @@
 
 using Deque.AxeCore.Playwright.AxeContent;
 using Microsoft.Playwright;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using Moq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Deque.AxeCore.Playwright.Test
 {
-    [TestClass]
+    [TestFixture]
+    [Category("Unit")]
     public sealed class AxeContentEmbedderTests
     {
-        [TestMethod]
-        [DataRow(false, 1, 0)]
-        [DataRow(true, 0, 1)]
-        [DataRow(null, 0, 1)]
+        [Test]
+        [TestCase(false, 1, 0)]
+        [TestCase(true, 0, 1)]
+        [TestCase(null, 0, 1)]
         public async Task EmbedAxeCoreIntoPage_NoIFrames_EmbedsIntoPage(bool? embedIntoFrames, int expectedPageEvalCount, int expectedIframeEvalCount)
         {
             const string axeContent = "() => void";

--- a/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
+++ b/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.25.0" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
+++ b/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
@@ -11,15 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-	  <PackageReference Include="Microsoft.Playwright" Version="1.20.2" />
-	  <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.20.2" />
-	  <PackageReference Include="Moq" Version="4.17.2" />
-	  <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-	  <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
-	  <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.25.0" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
+++ b/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
@@ -38,4 +42,8 @@
 	<Target Name="InstallPlaywright" AfterTargets="AfterBuild">
 		<Exec Command="pwsh -NoProfile -ExecutionPolicy Unrestricted ./$(OutDir)playwright.ps1 install"></Exec>
 	</Target>
+
+  <PropertyGroup>
+    <VSTestResultsDirectory>TestResults/$(TargetFramework)</VSTestResultsDirectory>
+	</PropertyGroup>
 </Project>

--- a/packages/playwright/test/IntegrationTests.cs
+++ b/packages/playwright/test/IntegrationTests.cs
@@ -183,8 +183,8 @@ namespace Deque.AxeCore.Playwright.Test
             await NavigateToPage("basic.html");
 
             AxeResults axeResults = await Page!.RunAxe(new AxeRunOptions(xpath: true));
-            var violationsWithoutAncestry = axeResults.Violations.Where(violation => violation.Nodes!.Any(node => node.XPath == null || !node.XPath.Any()));
-            Assert.That(violationsWithoutAncestry, Is.Empty);
+            var violationsWithoutXPath = axeResults.Violations.Where(violation => violation.Nodes!.Any(node => node.XPath == null || !node.XPath.Any()));
+            Assert.That(violationsWithoutXPath, Is.Empty);
         }
 
         [Test]

--- a/packages/selenium/test/AxeResultTargetConverterTest.cs
+++ b/packages/selenium/test/AxeResultTargetConverterTest.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using System.IO;
 using System.Linq;
@@ -26,7 +27,7 @@ namespace Deque.AxeCore.Selenium.Test
             var json = $@"{{""target"":[""{testObject.Selector}""]}}";
             var axeResultTarget = DeserializeJsonAndReturnFirstTarget(json);
 
-            Assert.AreEqual(axeResultTarget?.Selector, testObject.Selector);
+            axeResultTarget?.Selector.Should().Be(testObject.Selector);
         }
 
         [Test]
@@ -40,8 +41,7 @@ namespace Deque.AxeCore.Selenium.Test
 
             var axeResultTarget = DeserializeJsonAndReturnFirstTarget(json);
 
-            Assert.AreEqual(axeResultTarget?.Selectors.First(), testObject.Selectors.First());
-            Assert.AreEqual(axeResultTarget?.Selectors.Last(), testObject.Selectors.Last());
+            axeResultTarget?.Selectors.Should().ContainInOrder(testObject.Selectors);
         }
 
         [Test]

--- a/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
+++ b/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProjectGuid>{7D5DB0A8-263E-40D4-90C8-B86BA672C783}</ProjectGuid>
+    <!--
+      This list should be maintained in sync with
+      https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core and
+      https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
+    -->
     <TargetFrameworks>net471;netcoreapp3.1;net6.0</TargetFrameworks>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <AssemblyTitle>Deque.AxeCore.Selenium.Test</AssemblyTitle>
-    <Product>Deque.AxeCore.Selenium.Test</Product>
+
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
     <None Remove="SampleResults.json" />
   </ItemGroup>
@@ -21,8 +24,13 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -36,10 +44,12 @@
     <PackageReference Include="WebDriverManager" Version="2.15.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\src\Deque.AxeCore.Selenium.csproj" />
   </ItemGroup>
+
   <PropertyGroup>
-		<VSTestLogger>trx%3bLogFileName=Results$(TargetFramework).trx</VSTestLogger>
+    <VSTestResultsDirectory>TestResults/$(TargetFramework)</VSTestResultsDirectory>
 	</PropertyGroup>
 </Project>

--- a/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
+++ b/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
@@ -22,21 +22,19 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="Selenium.Support" Version="4.4.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="WebDriverManager" Version="2.14.1" />
+    <PackageReference Include="WebDriverManager" Version="2.15.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Deque.AxeCore.Selenium.csproj" />

--- a/packages/selenium/test/IntegrationTests.cs
+++ b/packages/selenium/test/IntegrationTests.cs
@@ -1,11 +1,8 @@
 ﻿using FluentAssertions;
-using HtmlAgilityPack;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Support.Events;
 using OpenQA.Selenium.Support.UI;
 using System;
 using System.Collections.Concurrent;
@@ -129,16 +126,17 @@ namespace Deque.AxeCore.Selenium.Test
                 .Violations
                 .FirstOrDefault(x => x.Id == "color-contrast");
 
-            Assert.IsNotNull(colorContrast);
-            Assert.AreEqual(3 /* including 1 from the top-level frame and 2 from the iframe */, colorContrast.Nodes.Length);
+            colorContrast.Should().NotBeNull();
+            colorContrast.Nodes.Should().HaveCount(3); // including 1 from the top-level frame and 2 from the iframe
 
             var shadowDomIframeTargetNode = colorContrast
                 .Nodes
                 .Where(x => x.Target.Any(node => node.Selectors.Any()))
                 .Select(x => x.Target.Last())
                 .First();
-            Assert.IsNotNull(shadowDomIframeTargetNode);
-            Assert.IsTrue(shadowDomIframeTargetNode.Selectors.Count == 2);
+
+            shadowDomIframeTargetNode.Should().NotBeNull();
+            shadowDomIframeTargetNode.Selectors.Should().HaveCount(2);
         }
 
         [Test]
@@ -159,8 +157,8 @@ namespace Deque.AxeCore.Selenium.Test
                 .Violations
                 .FirstOrDefault(x => x.Id == "color-contrast");
 
-            Assert.IsNotNull(colorContrast);
-            Assert.AreEqual(1 /* missing the 2 from the iframe */, colorContrast.Nodes.Length);
+            colorContrast.Should().NotBeNull();
+            colorContrast.Nodes.Should().HaveCount(1); // missing the 2 from the iframe
         }
 
         private void LoadSimpleTestPage()

--- a/packages/selenium/test/IntegrationTests.cs
+++ b/packages/selenium/test/IntegrationTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 using WebDriverManager;
 using WebDriverManager.DriverConfigs;
@@ -25,6 +26,7 @@ namespace Deque.AxeCore.Selenium.Test
     {
         private readonly ConcurrentDictionary<string, IWebDriver> localDriver = new ConcurrentDictionary<string, IWebDriver>();
         private readonly ConcurrentDictionary<string, WebDriverWait> localWaitDriver = new ConcurrentDictionary<string, WebDriverWait>();
+        private readonly ConcurrentDictionary<string, FirefoxWebDriverLogHook> localWebDriverLogHook = new ConcurrentDictionary<string, FirefoxWebDriverLogHook>();
 
         private static string ChromeDriverPath = null;
         private static string FirefoxDriverPath = null;
@@ -59,6 +61,21 @@ namespace Deque.AxeCore.Selenium.Test
             }
         }
 
+        private FirefoxWebDriverLogHook WebDriverLogHook
+        {
+            get
+            {
+                FirefoxWebDriverLogHook value;
+                localWebDriverLogHook.TryGetValue(GetFullyQualifiedTestName(), out value);
+                return value;
+            }
+
+            set
+            {
+                localWebDriverLogHook.AddOrUpdate(GetFullyQualifiedTestName(), value, (oldkey, oldvalue) => value);
+            }
+        }
+
         private static readonly string TestFileRoot = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         private static readonly string IntegrationTestTargetSimpleFile = Path.Combine(TestFileRoot, @"integration-test-simple.html");
         private static readonly string IntegrationTestTargetComplexTargetsFile = Path.Combine(TestFileRoot, @"integration-test-target-complex.html");
@@ -70,6 +87,7 @@ namespace Deque.AxeCore.Selenium.Test
         public virtual void TearDown()
         {
             WebDriver?.Quit();
+            WebDriverLogHook?.WriteLogs();
             WebDriver?.Dispose();
         }
 
@@ -171,7 +189,10 @@ namespace Deque.AxeCore.Selenium.Test
 
         private void InitDriver(string browser)
         {
-            string logPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"{browser}-webdriver-logs", TestContext.CurrentContext.Test.Name);
+            string logDirPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "TestResults", "verbose-logs", $"{browser}-webdriver");
+            string logFilePath = Path.Combine(logDirPath, $"{GetTestNameAsFileName()}.log");
+
+            Directory.CreateDirectory(logDirPath);
 
             switch (browser.ToUpper())
             {
@@ -189,8 +210,7 @@ namespace Deque.AxeCore.Selenium.Test
                     chromeOptions.AddArgument("--allow-file-access-from-files");
 
                     ChromeDriverService chromeService = ChromeDriverService.CreateDefaultService(Path.GetDirectoryName(ChromeDriverPath));
-                    chromeService.SuppressInitialDiagnosticInformation = true;
-                    chromeService.LogPath = logPath;
+                    chromeService.LogPath = logFilePath;
                     WebDriver = new ChromeDriver(chromeService, chromeOptions);
 
                     break;
@@ -202,9 +222,8 @@ namespace Deque.AxeCore.Selenium.Test
                     firefoxOptions.AddArgument("-headless");
 
                     FirefoxDriverService firefoxService = FirefoxDriverService.CreateDefaultService(Path.GetDirectoryName(FirefoxDriverPath));
-                    firefoxService.SuppressInitialDiagnosticInformation = true;
+                    WebDriverLogHook = new FirefoxWebDriverLogHook(firefoxService, logFilePath);
                     WebDriver = new FirefoxDriver(firefoxService, firefoxOptions);
-
                     break;
 
                 default:
@@ -215,6 +234,48 @@ namespace Deque.AxeCore.Selenium.Test
             Wait = new WebDriverWait(WebDriver, TimeSpan.FromSeconds(20));
             WebDriver.Manage().Timeouts().AsynchronousJavaScript = TimeSpan.FromSeconds(20);
             WebDriver.Manage().Window.Maximize();
+        }
+
+        // This is a workaround for FirefoxDriverService not natively implementing a LogPath option like ChromeDriverService
+        // See https://github.com/SeleniumHQ/selenium/issues/7259#issuecomment-498827403
+        private class FirefoxWebDriverLogHook {
+            private StreamReader stdOut;
+            private StreamReader stdErr;
+            private readonly string logPath;
+
+            public FirefoxWebDriverLogHook(FirefoxDriverService service, string logPath)
+            {
+                service.DriverProcessStarted += OnFirefoxDriverProcessStarted;
+                service.DriverProcessStarting += OnFirefoxDriverProcessStarting;
+                this.logPath = logPath;
+            }
+
+            private void OnFirefoxDriverProcessStarting(object sender, DriverProcessStartingEventArgs e)
+            {
+                // Redirect both stdout and stderr to get the output to both locations.
+                e.DriverServiceProcessStartInfo.UseShellExecute = false;
+                e.DriverServiceProcessStartInfo.RedirectStandardOutput = true;
+                e.DriverServiceProcessStartInfo.RedirectStandardError = true;
+            }
+
+            private void OnFirefoxDriverProcessStarted(object sender, DriverProcessStartedEventArgs e)
+            {
+                // Hook into the stream readers for both stdout and stderr.
+                stdOut = e.StandardOutputStreamReader;
+                stdErr = e.StandardErrorStreamReader;
+            }
+
+            public void WriteLogs() {
+                if (stdOut == null || stdErr == null) {
+                    return;
+                }
+
+                string stdOutContent = stdOut.ReadToEnd();
+                string stdErrContent = stdErr.ReadToEnd();
+
+                File.WriteAllText(logPath + ".stdout", stdOut.ReadToEnd());
+                File.WriteAllText(logPath + ".stderr", stdErr.ReadToEnd());
+            }
         }
 
         private static void EnsureWebdriverPathInitialized(ref string driverPath, string dirEnvVar, string binaryName, IDriverConfig driverManagerConfig) {
@@ -231,6 +292,11 @@ namespace Deque.AxeCore.Selenium.Test
         private static string GetFullyQualifiedTestName()
         {
             return TestContext.CurrentContext.Test.FullName;
+        }
+
+        private static string GetTestNameAsFileName()
+        {
+            return Regex.Replace(TestContext.CurrentContext.Test.Name, "[^\\w_ -]", "_");
         }
     }
 }

--- a/packages/selenium/test/IntegrationTests.cs
+++ b/packages/selenium/test/IntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -171,6 +171,8 @@ namespace Deque.AxeCore.Selenium.Test
 
         private void InitDriver(string browser)
         {
+            string logPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"{browser}-webdriver-logs", TestContext.CurrentContext.Test.Name);
+
             switch (browser.ToUpper())
             {
                 case "CHROME":
@@ -186,9 +188,10 @@ namespace Deque.AxeCore.Selenium.Test
                     chromeOptions.AddArgument("--silent");
                     chromeOptions.AddArgument("--allow-file-access-from-files");
 
-                    ChromeDriverService service = ChromeDriverService.CreateDefaultService(Path.GetDirectoryName(ChromeDriverPath));
-                    service.SuppressInitialDiagnosticInformation = true;
-                    WebDriver = new ChromeDriver(ChromeDriverService.CreateDefaultService(), chromeOptions);
+                    ChromeDriverService chromeService = ChromeDriverService.CreateDefaultService(Path.GetDirectoryName(ChromeDriverPath));
+                    chromeService.SuppressInitialDiagnosticInformation = true;
+                    chromeService.LogPath = logPath;
+                    WebDriver = new ChromeDriver(chromeService, chromeOptions);
 
                     break;
 
@@ -198,7 +201,10 @@ namespace Deque.AxeCore.Selenium.Test
                     FirefoxOptions firefoxOptions = new FirefoxOptions();
                     firefoxOptions.AddArgument("-headless");
 
-                    WebDriver = new FirefoxDriver(Path.GetDirectoryName(FirefoxDriverPath), firefoxOptions);
+                    FirefoxDriverService firefoxService = FirefoxDriverService.CreateDefaultService(Path.GetDirectoryName(FirefoxDriverPath));
+                    firefoxService.SuppressInitialDiagnosticInformation = true;
+                    WebDriver = new FirefoxDriver(firefoxService, firefoxOptions);
+
                     break;
 
                 default:


### PR DESCRIPTION
## Details

This PR standardizes the assorted test projects such that they run and produce output in a reliable, actionable format. Specifically:

* It migrates the playwright test project from MSTest to NUnit
* It updates all test dependencies to consistent, latest versions
  * It fixes a few new NUnit warnings suggesting migration from `Assert.IsEqual(expected, actual)` type syntax to `Assert.That(actual, Is.EqualTo(expected))` syntax
* It adds a new dependency on GitHubActionsTestLogger from each test project to produce actionable GitHub Actions output
* It standardizes the test results directory on `TestResults/$(TargetFramework)` to avoid result files for the different frameworks from stomping on each other
* It updates the PR build `--logger` config to:
  * use a more minimal console logger verbosity, to avoid some of the misleading console spew
  * log both a human-readable `html` format and a machine-readable `trx` format to the `test-results` artifact for each test project/framework combination
  * enable the GitHubActionsTestLogger

I attempted to redirect the selenium tests' browser/webdriver logs off of the main test standard output, but ran into difficulties because Selenium's .NET binding for geckodriver [doesn't support redirecting logs to a file](https://github.com/SeleniumHQ/selenium/issues/7259) like it does for chromedriver, and intends not to until [geckodriver implements its own equivalent](https://bugzilla.mozilla.org/show_bug.cgi?id=1611003). I tried following the workarounds suggested in the thread but ran into issues getting them to work reliably cross-platform; I ended up hitting my timebox for it and abandoning it. The raw test console output is less important now that there are better alternatives set up for GHA integration and readable `test-results` artifact contents.

Closes Issue: #41