### PR TITLE
feat(commons): move selenium typings to common typings

### DIFF
--- a/packages/commons/README.md
+++ b/packages/commons/README.md
@@ -4,7 +4,7 @@ Provides a .NET wrapper around [axe-core](https://github.com/dequelabs/axe-core)
 
 ## Getting Started
 
-*Note: this package is still under development; these instructions won't work until we perform an initial NuGet release*
+_Note: this package is still under development; these instructions won't work until we perform an initial NuGet release_
 
 Install a [.NET SDK](https://dotnet.microsoft.com/download) if you haven't already.
 
@@ -18,8 +18,20 @@ dotnet add package Deque.AxeCore.Commons
 
 This package exists primarily to help .NET tool developers integrate `axe-core` with different tools and test frameworks. If you are just trying to write test cases using `axe-core`, you probably want to use one of these instead:
 
-* [Deque.AxeCore.Playwright](../playwright/README.md) in combination with [Playwright for .NET](https://playwright.dev/dotnet/)
-* [Deque.AxeCore.Selenium](../selenium/README.md) in combination with [Selenium](https://www.selenium.dev/)'s [C# Selenium.WebDriver package](https://www.nuget.org/packages/Selenium.WebDriver)
+- [Deque.AxeCore.Playwright](../playwright/README.md) in combination with [Playwright for .NET](https://playwright.dev/dotnet/)
+- [Deque.AxeCore.Selenium](../selenium/README.md) in combination with [Selenium](https://www.selenium.dev/)'s [C# Selenium.WebDriver package](https://www.nuget.org/packages/Selenium.WebDriver)
+
+### `AxeResult`
+
+`AxeResult` represents the [axe-core Results Object](https://www.deque.com/axe/core-documentation/api-documentation/#results-object).
+
+### `AxeRunContext`
+
+`AxeRunContext` represents the [axe-core Context Parameter](https://www.deque.com/axe/core-documentation/api-documentation/#context-parameter).
+
+### `AxeRunOptions`
+
+`AxeRunOptions` represents the [axe-core Options Parameter](https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter).
 
 ## License
 

--- a/packages/commons/README.md
+++ b/packages/commons/README.md
@@ -4,7 +4,7 @@ Provides a .NET wrapper around [axe-core](https://github.com/dequelabs/axe-core)
 
 ## Getting Started
 
-_Note: this package is still under development; these instructions won't work until we perform an initial NuGet release_
+*Note: this package is still under development; these instructions won't work until we perform an initial NuGet release*
 
 Install a [.NET SDK](https://dotnet.microsoft.com/download) if you haven't already.
 
@@ -18,8 +18,8 @@ dotnet add package Deque.AxeCore.Commons
 
 This package exists primarily to help .NET tool developers integrate `axe-core` with different tools and test frameworks. If you are just trying to write test cases using `axe-core`, you probably want to use one of these instead:
 
-- [Deque.AxeCore.Playwright](../playwright/README.md) in combination with [Playwright for .NET](https://playwright.dev/dotnet/)
-- [Deque.AxeCore.Selenium](../selenium/README.md) in combination with [Selenium](https://www.selenium.dev/)'s [C# Selenium.WebDriver package](https://www.nuget.org/packages/Selenium.WebDriver)
+* [Deque.AxeCore.Playwright](../playwright/README.md) in combination with [Playwright for .NET](https://playwright.dev/dotnet/)
+* [Deque.AxeCore.Selenium](../selenium/README.md) in combination with [Selenium](https://www.selenium.dev/)'s [C# Selenium.WebDriver package](https://www.nuget.org/packages/Selenium.WebDriver)
 
 ### `AxeResult`
 

--- a/packages/commons/src/AssemblyInfo.cs
+++ b/packages/commons/src/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Deque.AxeCore.Commons.Test")]

--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     public class AxeResult
     {

--- a/packages/commons/src/AxeResultCheck.cs
+++ b/packages/commons/src/AxeResultCheck.cs
@@ -1,4 +1,4 @@
-﻿namespace Deque.AxeCore.Selenium
+﻿namespace Deque.AxeCore.Commons
 {
     public class AxeResultCheck
     {

--- a/packages/commons/src/AxeResultItem.cs
+++ b/packages/commons/src/AxeResultItem.cs
@@ -1,4 +1,4 @@
-﻿namespace Deque.AxeCore.Selenium
+﻿namespace Deque.AxeCore.Commons
 {
     public class AxeResultItem
     {

--- a/packages/commons/src/AxeResultNode.cs
+++ b/packages/commons/src/AxeResultNode.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     public class AxeResultNode
     {

--- a/packages/commons/src/AxeResultRelatedNode.cs
+++ b/packages/commons/src/AxeResultRelatedNode.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     public class AxeResultRelatedNode
     {

--- a/packages/commons/src/AxeResultTarget.cs
+++ b/packages/commons/src/AxeResultTarget.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     /// <summary>
     /// With AxeResultTarget,  we will have either a <see cref="Selector"/> or <see cref="Selectors"/> for each target.

--- a/packages/commons/src/AxeResultTargetConverter.cs
+++ b/packages/commons/src/AxeResultTargetConverter.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     class AxeResultTargetConverter : JsonConverter
     {

--- a/packages/commons/src/AxeRunContext.cs
+++ b/packages/commons/src/AxeRunContext.cs
@@ -1,13 +1,13 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     /// <summary>
     /// Has the list of selectors that have to be included or excluded from scanning. If not specified the whole document will be scanned
     /// </summary>
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-    internal class AxeRunContext
+    public class AxeRunContext
     {
         [JsonProperty("include")]
         public List<string[]> Include { get; set; }

--- a/packages/commons/src/AxeRunOptions.cs
+++ b/packages/commons/src/AxeRunOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace Deque.AxeCore.Selenium
+namespace Deque.AxeCore.Commons
 {
     /// <summary>
     /// Used as part of <see cref="AxeRunOptions" to configure rules/tags to be executed/>

--- a/packages/commons/src/AxeTestEnvironment.cs
+++ b/packages/commons/src/AxeTestEnvironment.cs
@@ -1,4 +1,4 @@
-﻿namespace Deque.AxeCore.Selenium
+﻿namespace Deque.AxeCore.Commons
 {
     public class AxeTestEnvironment
     {

--- a/packages/commons/src/Deque.AxeCore.Commons.csproj
+++ b/packages/commons/src/Deque.AxeCore.Commons.csproj
@@ -22,7 +22,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../../LICENSE-Deque.AxeCore.Commons.txt" Pack="true" PackagePath="LICENSE.txt"/>
-    <None Include="../../../NOTICE.txt" Pack="true" PackagePath="NOTICE.txt"/>
+    <None Include="../../../LICENSE-Deque.AxeCore.Commons.txt" Pack="true" PackagePath="LICENSE.txt" />
+    <None Include="../../../NOTICE.txt" Pack="true" PackagePath="NOTICE.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NewtonSoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/packages/commons/test/AxeResultTargetConverterTest.cs
+++ b/packages/commons/test/AxeResultTargetConverterTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using System.IO;
 using System.Linq;
 
-namespace Deque.AxeCore.Selenium.Test
+namespace Deque.AxeCore.Commons.Test
 {
     [TestFixture]
     public class AxeResultTargetConverterTest

--- a/packages/commons/test/AxeRunContextTest.cs
+++ b/packages/commons/test/AxeRunContextTest.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Collections.Generic;
 
-namespace Deque.AxeCore.Selenium.Test
+namespace Deque.AxeCore.Commons.Test
 {
     [TestFixture]
     public class AxeRunContextTest

--- a/packages/commons/test/AxeRunOptionsTest.cs
+++ b/packages/commons/test/AxeRunOptionsTest.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Collections.Generic;
 
-namespace Deque.AxeCore.Selenium.Test
+namespace Deque.AxeCore.Commons.Test
 {
     [TestFixture]
     public class AxeRunOptionsTest

--- a/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
+++ b/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
@@ -11,7 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NewtonSoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -1,7 +1,7 @@
 # Deque.AxeCore.Selenium
 
-[![Deque.AxeCore.Selenium NuGet package](https://img.shields.io/nuget/v/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium) 
-[![NuGet package download counter](https://img.shields.io/nuget/dt/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium/) 
+[![Deque.AxeCore.Selenium NuGet package](https://img.shields.io/nuget/v/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium)
+[![NuGet package download counter](https://img.shields.io/nuget/dt/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium/)
 
 Automated web accessibility testing with .NET, C#, and Selenium. Wraps the [axe-core](https://github.com/dequelabs/axe-core) accessibility scanning engine and the [Selenium.WebDriver](https://www.seleniumhq.org/) browser automation framework.
 
@@ -19,6 +19,7 @@ PM> Install-Package Deque.AxeCore.Selenium
 Import this namespace:
 
 ```csharp
+using Deque.AxeCore.Commons;
 using Deque.AxeCore.Selenium;
 ```
 
@@ -79,7 +80,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
     .Analyze();
 ```
 
-Scopes future `Analyze()` calls to include *only* the element(s) matching the given CSS selector.
+Scopes future `Analyze()` calls to include _only_ the element(s) matching the given CSS selector.
 
 `Include` may be chained multiple times to include multiple selectors in a scan.
 
@@ -219,7 +220,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
 
 ### `AxeBuilder.WithOptions(AxeRunOptions options)`
 
-*Note: in most cases, the simpler `WithRules`, `WithTags`, and `DisableRules` can be used instead.*
+_Note: in most cases, the simpler `WithRules`, `WithTags`, and `DisableRules` can be used instead._
 
 ```csharp
 AxeResult axeResult = new AxeBuilder(webDriver)
@@ -242,6 +243,7 @@ Causes future calls to `Analyze` to use the specified options when calling `axe.
 `WithOptions` is not compatible with the deprecated raw `Options` property.
 
 #### Skip iFrames
+
 If you don't want to run Axe on iFrames you can tell Axe skip with AxeRunOptions.
 
 ```csharp
@@ -252,6 +254,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
     })
     .Analyze();
 ```
+
 Prevents Axe core from getting injected into page iFrames.
 
 Causes future calls to `Analyze` to use the specified options when calling `axe.run` in axe-core. See [the axe-core API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) for descriptions of the different properties of `AxeRunOptions`.
@@ -264,7 +267,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
     .Analyze();
 ```
 
-Causes future calls to `Analyze` to export their results to a JSON file, *in addition* to being returned as an `AxeResult` object as usual.
+Causes future calls to `Analyze` to export their results to a JSON file, _in addition_ to being returned as an `AxeResult` object as usual.
 
 The output format is exactly the same as axe-core would have produced natively, and is compatible with other tools that read axe result JSON, like [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter).
 
@@ -280,9 +283,9 @@ AxeBuilderOptions axeBuilderOptions = new AxeBuilderOptions
 AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 ```
 
-### *Deprecated*: `AxeBuilder.Options`
+### _Deprecated_: `AxeBuilder.Options`
 
-*This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`*
+_This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`_
 
 ```csharp
 AxeBuilder axeBuilder = new AxeBuilder(webDriver);

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -1,7 +1,7 @@
 # Deque.AxeCore.Selenium
 
-[![Deque.AxeCore.Selenium NuGet package](https://img.shields.io/nuget/v/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium)
-[![NuGet package download counter](https://img.shields.io/nuget/dt/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium/)
+[![Deque.AxeCore.Selenium NuGet package](https://img.shields.io/nuget/v/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium) 
+[![NuGet package download counter](https://img.shields.io/nuget/dt/Deque.AxeCore.Selenium)](https://www.nuget.org/packages/Deque.AxeCore.Selenium/) 
 
 Automated web accessibility testing with .NET, C#, and Selenium. Wraps the [axe-core](https://github.com/dequelabs/axe-core) accessibility scanning engine and the [Selenium.WebDriver](https://www.seleniumhq.org/) browser automation framework.
 
@@ -80,7 +80,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
     .Analyze();
 ```
 
-Scopes future `Analyze()` calls to include _only_ the element(s) matching the given CSS selector.
+Scopes future `Analyze()` calls to include *only* the element(s) matching the given CSS selector.
 
 `Include` may be chained multiple times to include multiple selectors in a scan.
 
@@ -220,7 +220,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
 
 ### `AxeBuilder.WithOptions(AxeRunOptions options)`
 
-_Note: in most cases, the simpler `WithRules`, `WithTags`, and `DisableRules` can be used instead._
+*Note: in most cases, the simpler `WithRules`, `WithTags`, and `DisableRules` can be used instead.*
 
 ```csharp
 AxeResult axeResult = new AxeBuilder(webDriver)
@@ -243,7 +243,6 @@ Causes future calls to `Analyze` to use the specified options when calling `axe.
 `WithOptions` is not compatible with the deprecated raw `Options` property.
 
 #### Skip iFrames
-
 If you don't want to run Axe on iFrames you can tell Axe skip with AxeRunOptions.
 
 ```csharp
@@ -254,7 +253,6 @@ AxeResult axeResult = new AxeBuilder(webDriver)
     })
     .Analyze();
 ```
-
 Prevents Axe core from getting injected into page iFrames.
 
 Causes future calls to `Analyze` to use the specified options when calling `axe.run` in axe-core. See [the axe-core API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) for descriptions of the different properties of `AxeRunOptions`.
@@ -267,7 +265,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
     .Analyze();
 ```
 
-Causes future calls to `Analyze` to export their results to a JSON file, _in addition_ to being returned as an `AxeResult` object as usual.
+Causes future calls to `Analyze` to export their results to a JSON file, *in addition* to being returned as an `AxeResult` object as usual.
 
 The output format is exactly the same as axe-core would have produced natively, and is compatible with other tools that read axe result JSON, like [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter).
 
@@ -283,9 +281,9 @@ AxeBuilderOptions axeBuilderOptions = new AxeBuilderOptions
 AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 ```
 
-### _Deprecated_: `AxeBuilder.Options`
+### *Deprecated*: `AxeBuilder.Options`
 
-_This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`_
+*This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`*
 
 ```csharp
 AxeBuilder axeBuilder = new AxeBuilder(webDriver);

--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Deque.AxeCore.Commons;
 
 namespace Deque.AxeCore.Selenium
 {

--- a/packages/selenium/src/WebDriverExtensions.cs
+++ b/packages/selenium/src/WebDriverExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using OpenQA.Selenium;
 using System;
+using Deque.AxeCore.Commons;
 
 namespace Deque.AxeCore.Selenium
 {

--- a/packages/selenium/test/AxeBuilderTest.cs
+++ b/packages/selenium/test/AxeBuilderTest.cs
@@ -6,6 +6,7 @@ using OpenQA.Selenium;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Deque.AxeCore.Commons;
 
 namespace Deque.AxeCore.Selenium.Test
 {

--- a/packages/selenium/test/IntegrationTests.cs
+++ b/packages/selenium/test/IntegrationTests.cs
@@ -151,8 +151,7 @@ namespace Deque.AxeCore.Selenium.Test
             WebDriver.Navigate().GoToUrl(filename);
 
             var axeResult = new AxeBuilder(WebDriver)
-                .WithOptions(new AxeRunOptions
-                {
+                .WithOptions(new AxeRunOptions {
                     Iframes = false
                 })
                 .Analyze();
@@ -215,17 +214,12 @@ namespace Deque.AxeCore.Selenium.Test
             WebDriver.Manage().Window.Maximize();
         }
 
-        private static void EnsureWebdriverPathInitialized(ref string driverPath, string dirEnvVar, string binaryName, IDriverConfig driverManagerConfig)
-        {
-            LazyInitializer.EnsureInitialized(ref driverPath, () =>
-            {
+        private static void EnsureWebdriverPathInitialized(ref string driverPath, string dirEnvVar, string binaryName, IDriverConfig driverManagerConfig) {
+            LazyInitializer.EnsureInitialized(ref driverPath, () => {
                 var dirFromEnv = Environment.GetEnvironmentVariable(dirEnvVar);
-                if (dirFromEnv != null)
-                {
+                if (dirFromEnv != null) {
                     return $"{dirFromEnv}/${binaryName}";
-                }
-                else
-                {
+                } else {
                     return new DriverManager().SetUpDriver(driverManagerConfig);
                 }
             });

--- a/packages/selenium/test/IntegrationTests.cs
+++ b/packages/selenium/test/IntegrationTests.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using WebDriverManager;
 using WebDriverManager.DriverConfigs;
 using WebDriverManager.DriverConfigs.Impl;
+using Deque.AxeCore.Commons;
 
 // Setup parallelization
 [assembly: Parallelizable(ParallelScope.All)]
@@ -150,7 +151,8 @@ namespace Deque.AxeCore.Selenium.Test
             WebDriver.Navigate().GoToUrl(filename);
 
             var axeResult = new AxeBuilder(WebDriver)
-                .WithOptions(new AxeRunOptions {
+                .WithOptions(new AxeRunOptions
+                {
                     Iframes = false
                 })
                 .Analyze();
@@ -213,12 +215,17 @@ namespace Deque.AxeCore.Selenium.Test
             WebDriver.Manage().Window.Maximize();
         }
 
-        private static void EnsureWebdriverPathInitialized(ref string driverPath, string dirEnvVar, string binaryName, IDriverConfig driverManagerConfig) {
-            LazyInitializer.EnsureInitialized(ref driverPath, () => {
+        private static void EnsureWebdriverPathInitialized(ref string driverPath, string dirEnvVar, string binaryName, IDriverConfig driverManagerConfig)
+        {
+            LazyInitializer.EnsureInitialized(ref driverPath, () =>
+            {
                 var dirFromEnv = Environment.GetEnvironmentVariable(dirEnvVar);
-                if (dirFromEnv != null) {
+                if (dirFromEnv != null)
+                {
                     return $"{dirFromEnv}/${binaryName}";
-                } else {
+                }
+                else
+                {
                     return new DriverManager().SetUpDriver(driverManagerConfig);
                 }
             });


### PR DESCRIPTION
## Details
<!-- Provide a sentence or two describing what the PR changes -->
This PR addresses #9 by moving the typings from the `selenium` package to the `commons` package. The README files in both packages have also been updated to reflect the moved typings files. The `playwright` package will be updated to use the `commons` typings in another PR.

Ran `dotnet test` to verify changes.

Closes Issue: #9 