### PR TITLE
feat: add source control metadata to packages

### DIFF
--- a/packages/commons/src/Deque.AxeCore.Commons.csproj
+++ b/packages/commons/src/Deque.AxeCore.Commons.csproj
@@ -26,6 +26,10 @@
     <None Include="../../../NOTICE.txt" Pack="true" PackagePath="NOTICE.txt"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+  </ItemGroup>
+
   <!-- Running this using BeforeTagets="Restore" doesn't work if we run "dotnet restore" from solution folder. 
        Running it before CollectPackageReferences, will work in both vs & command line. But, this task will be executed in both build & restore multiple times on multi-target project.
        So, skipping this task if the copied package-lock.json file is same as the source file, to support incremental builds.

--- a/packages/playwright/src/Deque.AxeCore.Playwright.csproj
+++ b/packages/playwright/src/Deque.AxeCore.Playwright.csproj
@@ -58,6 +58,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright" Version="1.20.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="System.IO.Abstractions" Version="17.0.24" />
   </ItemGroup>
 

--- a/packages/selenium/src/Deque.AxeCore.Selenium.csproj
+++ b/packages/selenium/src/Deque.AxeCore.Selenium.csproj
@@ -28,12 +28,11 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.4.0" />
+
+    
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Details
This PR adds source-linking metadata to each package using [SourceLink](https://github.com/dotnet/sourcelink), which allows IDEs to find the specific source commit/line during debugging that involves the packages. It does this by following the sourcelink docs to add a development-time (`PrivateAssets="All"`) reference on `Microsoft.SourceLink.GitHub`.

The selenium package already had a (unnecessarily verbose) version of this in place; this PR updates all 3 packages to consistently use the recommended form of sourcelink reference.

You can verify the results of this by building, opening up the resulting `.nupkg` files, and finding a line like this embedded automatically into the included `.nuspec` file:

```xml
<repository type="git" url="https://github.com/dequelabs/axe-core-nuget" commit="b7b933324ab5201a361ef0a3b49a5fcae0494d19" />
```

Closes Issue: n/a