### PR TITLE
fix: remove unnecessary dep from selenium package on HtmlAgilityPack

### DIFF
--- a/packages/selenium/src/Deque.AxeCore.Selenium.csproj
+++ b/packages/selenium/src/Deque.AxeCore.Selenium.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Details
Removes an obsolete dependency on the `HtmlAgilityPack` package. This dependency was part of the HTML reporting functionality removed in #40 , but that PR missed removing the `PackageReference`.

Closes Issue: n/a