### PR TITLE
test: standardize on HEADED env var for headful browser testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,4 @@ You'll need the following installed:
 * To run one test project, run `dotnet test` from that test project's folder (eg, `packages/commons/test`)
 * To run one individual test case, run `dotnet test --filter "Name=TestCaseMethodName"`
   * `dotnet test --list-tests` will list the available test cases
+* To have integration tests use headed browsers instead of headless ones, run `dotnet test -e HEADED=1`

--- a/packages/playwright/test/IntegrationTests.cs
+++ b/packages/playwright/test/IntegrationTests.cs
@@ -17,9 +17,6 @@ namespace Deque.AxeCore.Playwright.Test
 
         public IntegrationTests()
         {
-#if DEBUG
-            Environment.SetEnvironmentVariable("HEADED", "1");
-#endif
             m_testServer = new();
         }
 

--- a/packages/selenium/test/IntegrationTests.cs
+++ b/packages/selenium/test/IntegrationTests.cs
@@ -173,6 +173,9 @@ namespace Deque.AxeCore.Selenium.Test
 
         private void InitDriver(string browser)
         {
+            string headedEnvVar = Environment.GetEnvironmentVariable("HEADED");
+            bool headless = headedEnvVar == null || headedEnvVar == "" || headedEnvVar == "0";
+
             switch (browser.ToUpper())
             {
                 case "CHROME":
@@ -182,7 +185,9 @@ namespace Deque.AxeCore.Selenium.Test
                     {
                         UnhandledPromptBehavior = UnhandledPromptBehavior.Accept,
                     };
-                    chromeOptions.AddArgument("--headless");
+                    if (headless) {
+                        chromeOptions.AddArgument("--headless");
+                    }
                     chromeOptions.AddArgument("no-sandbox");
                     chromeOptions.AddArgument("--log-level=3");
                     chromeOptions.AddArgument("--silent");
@@ -198,7 +203,9 @@ namespace Deque.AxeCore.Selenium.Test
                     EnsureWebdriverPathInitialized(ref FirefoxDriverPath, "GECKOWEBDRIVER", "geckodriver", new FirefoxConfig());
 
                     FirefoxOptions firefoxOptions = new FirefoxOptions();
-                    firefoxOptions.AddArgument("-headless");
+                    if (headless) {
+                        firefoxOptions.AddArgument("-headless");
+                    }
 
                     FirefoxDriverService firefoxService = FirefoxDriverService.CreateDefaultService(Path.GetDirectoryName(FirefoxDriverPath));
                     firefoxService.SuppressInitialDiagnosticInformation = true;


### PR DESCRIPTION
## Details
Before this PR, the behavior for choosing whether to use headless browsers (faster, less intrusive) vs headful browsers (helps debug some specific types of issues) differed between the Selenium and Playwright test projects:

* Playwright used headless browsers in "release" configuration (what PR/release builds use by default) and headful in "debug" builds (what `dotnet test` uses by default)
* Selenium always used headless

Neither of these were ideal; in most cases, you want the faster/less intrusive/more-consistent-with-PR-builds version when running `dotnet test`, but it's nice to be able to opt-in to headful testing for debugging issues where you want to see page state within a breakpoint.

This PR updates the logic for both projects to run headless by default regardless of build configuration, but to match [Playwright for NUnit's native support](https://playwright.dev/dotnet/docs/test-runners#nunit) for a `HEADED=1` environment variable, ie, running `dotnet test -e HEADED=1` will now run both the selenium and playwright test projects in headed mode, regardless of build configuration. It documents this support in `CONTRIBUTING.md`'s section on test commands.

Closes Issue: n/a