### PR TITLE
feat(selenium)!: remove deprecated Options property from AxeBuilder

### DIFF
--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -281,22 +281,6 @@ AxeBuilderOptions axeBuilderOptions = new AxeBuilderOptions
 AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 ```
 
-### *Deprecated*: `AxeBuilder.Options`
-
-*This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`*
-
-```csharp
-AxeBuilder axeBuilder = new AxeBuilder(webDriver);
-axeBuilder.Options = "{\"runOnly\": {\"type\": \"tag\", \"values\": [\"wcag2a\"]}, \"restoreScroll\": true}"
-AxeResult axeResult = axeBuilder.Analyze();
-```
-
-Sets a JSON string that will be passed as-is to the axe.run `options` parameter.
-
-See the [axe-core API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) for the format for the JSON string.
-
-`Options` is not compatible with `WithRules`, `WithTags`, `DisableRules`, or `WithOptions`
-
 ## Working with AxeResult objects
 
 In most cases, you would run an axe scan from within a test method in a suite of end to end tests, and you would want to use a test assertion to verify that there are no unexpected accessibility violations in a page or component.

--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -29,13 +29,6 @@ namespace Deque.AxeCore.Selenium
         };
 
         /// <summary>
-        /// The run options to be passed to axe. Refer https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter
-        /// Cannot not be used with <see cref="WithRules(string[])"/>, <see cref="WithTags(string[])"/> & <see cref="DisableRules(string[])"/>
-        /// </summary>
-        [Obsolete("Use WithOptions / WithTags / WithRules / DisableRules apis")]
-        public string Options { get; set; } = "{}";
-
-        /// <summary>
         /// Initialize an instance of <see cref="AxeBuilder"/>
         /// </summary>
         /// <param name="webDriver">Selenium driver to use</param>
@@ -66,8 +59,6 @@ namespace Deque.AxeCore.Selenium
         {
             ValidateNotNullParameter(runOptions, nameof(runOptions));
 
-            ThrowIfDeprecatedOptionsSet();
-
             this.runOptions = runOptions;
 
             return this;
@@ -82,8 +73,6 @@ namespace Deque.AxeCore.Selenium
         public AxeBuilder WithTags(params string[] tags)
         {
             ValidateParameters(tags, nameof(tags));
-
-            ThrowIfDeprecatedOptionsSet();
 
             runOptions.RunOnly = new RunOnlyOptions
             {
@@ -103,8 +92,6 @@ namespace Deque.AxeCore.Selenium
         {
             ValidateParameters(rules, nameof(rules));
 
-            ThrowIfDeprecatedOptionsSet();
-
             runOptions.RunOnly = new RunOnlyOptions
             {
                 Type = "rule",
@@ -123,8 +110,6 @@ namespace Deque.AxeCore.Selenium
         public AxeBuilder DisableRules(params string[] rules)
         {
             ValidateParameters(rules, nameof(rules));
-
-            ThrowIfDeprecatedOptionsSet();
 
             var rulesMap = new Dictionary<string, RuleOptions>();
             foreach (var rule in rules)
@@ -218,9 +203,7 @@ namespace Deque.AxeCore.Selenium
         {
             _webDriver.Inject(_AxeBuilderOptions.ScriptProvider, runOptions);
 
-#pragma warning disable CS0618 // Intentionally falling back to publicly deprecated property for backcompat
-            string rawOptionsArg = Options == "{}" ? JsonConvert.SerializeObject(runOptions, JsonSerializerSettings) : Options;
-#pragma warning restore CS0618
+            string rawOptionsArg = JsonConvert.SerializeObject(runOptions, JsonSerializerSettings);
 
             string scanJsContent = EmbeddedResourceProvider.ReadEmbeddedFile("scan.js");
             object[] rawArgs = new[] { rawContextArg, rawOptionsArg };
@@ -255,16 +238,6 @@ namespace Deque.AxeCore.Selenium
             if (parameterValue == null)
             {
                 throw new ArgumentNullException(parameterName);
-            }
-        }
-
-        private void ThrowIfDeprecatedOptionsSet()
-        {
-#pragma warning disable CS0618 // Intentionally checking publicly deprecated property for backcompat
-            if (Options != "{}")
-#pragma warning restore CS0618
-            {
-                throw new InvalidOperationException("Deprecated Options api shouldn't be used with the new apis - WithOptions/WithRules/WithTags or DisableRules");
             }
         }
     }

--- a/packages/selenium/test/AxeBuilderTest.cs
+++ b/packages/selenium/test/AxeBuilderTest.cs
@@ -160,52 +160,6 @@ namespace Deque.AxeCore.Selenium.Test
             jsExecutorMock.VerifyAll();
         }
 
-
-        [Test]
-        public void ShouldPassRunOptionsIfDeprecatedOptionsSet()
-        {
-            var expectedOptions = "deprecated run options";
-
-            SetupVerifiableAxeInjectionCall();
-            SetupVerifiableScanCall(null, expectedOptions);
-
-            var builder = new AxeBuilder(webDriverMock.Object, stubAxeBuilderOptions);
-#pragma warning disable CS0618
-            builder.Options = expectedOptions;
-#pragma warning restore CS0618
-
-            var result = builder.Analyze();
-
-            VerifyAxeResult(result);
-
-            webDriverMock.VerifyAll();
-            targetLocatorMock.VerifyAll();
-            jsExecutorMock.VerifyAll();
-        }
-
-        [Test]
-        public void ShouldPassRunOptionsIfDeprecatedOptionsSetWithContextElement()
-        {
-            var expectedOptions = "deprecated run options";
-            var expectedContext = new Mock<IWebElement>();
-
-            SetupVerifiableAxeInjectionCall();
-            SetupVerifiableScanElementCall(expectedContext.Object, expectedOptions);
-
-            var builder = new AxeBuilder(webDriverMock.Object, stubAxeBuilderOptions);
-#pragma warning disable CS0618
-            builder.Options = expectedOptions;
-#pragma warning restore CS0618
-
-            var result = builder.Analyze(expectedContext.Object);
-
-            VerifyAxeResult(result);
-
-            webDriverMock.VerifyAll();
-            targetLocatorMock.VerifyAll();
-            jsExecutorMock.VerifyAll();
-        }
-
         [Test]
         public void ShouldPassRuleConfig()
         {
@@ -331,22 +285,6 @@ namespace Deque.AxeCore.Selenium.Test
             VerifyExceptionThrown<ArgumentException>(() => builder.Exclude(values));
         }
 
-        [Test]
-        public void ShouldThrowIfDeprecatedOptionsIsUsedWithNewOptionsApis()
-        {
-            SetupVerifiableAxeInjectionCall();
-
-            var builder = new AxeBuilder(webDriverMock.Object, stubAxeBuilderOptions);
-#pragma warning disable CS0618
-            builder.Options = "{xpath:true}";
-#pragma warning restore CS0618
-
-            VerifyExceptionThrown<InvalidOperationException>(() => builder.WithRules("rule-1"));
-            VerifyExceptionThrown<InvalidOperationException>(() => builder.DisableRules("rule-1"));
-            VerifyExceptionThrown<InvalidOperationException>(() => builder.WithTags("tag1"));
-            VerifyExceptionThrown<InvalidOperationException>(() => builder.WithOptions(new AxeRunOptions() { Iframes = true }));
-        }
-
         private void VerifyExceptionThrown<T>(Action action) where T : Exception
         {
             action.Should().Throw<T>();
@@ -383,14 +321,6 @@ namespace Deque.AxeCore.Selenium.Test
             jsExecutorMock.Setup(js => js.ExecuteAsyncScript(
                 EmbeddedResourceProvider.ReadEmbeddedFile("scan.js"),
                 It.Is<string>(context => context == serializedContext),
-                It.Is<string>(options => options == serialzedOptions))).Returns(testAxeResult).Verifiable();
-        }
-
-        private void SetupVerifiableScanElementCall(IWebElement elementContext, string serialzedOptions)
-        {
-            jsExecutorMock.Setup(js => js.ExecuteAsyncScript(
-                EmbeddedResourceProvider.ReadEmbeddedFile("scan.js"),
-                elementContext,
                 It.Is<string>(options => options == serialzedOptions))).Returns(testAxeResult).Verifiable();
         }
 


### PR DESCRIPTION
## Details
This PR removes the already-deprecated `Options` property from the selenium package's `AxeBuilder`. This has been deprecated for some time and we're making breaking changes anyway with the new release, now is a good time to remove it.

Closes Issue: n/a

BREAKING CHANGE: removes a (already-deprecated) property