### PR TITLE
feat(commons): Add doc comments to commons typings

### DIFF
--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -5,21 +5,58 @@ namespace Deque.AxeCore.Commons
 {
     public class AxeResult
     {
+        /// <summary>
+        /// These results indicate what elements failed the rules.
+        /// </summary>
         public AxeResultItem[] Violations { get; }
+
+        /// <summary>
+        /// These results indicate what elements passed the rules.
+        /// </summary>
         public AxeResultItem[] Passes { get; }
+
+        /// <summary>
+        /// These results indicate which rules did not run because no matching content was found on the page. 
+        /// For example, with no video, those rules won't run.
+        /// </summary>
         public AxeResultItem[] Inapplicable { get; }
+
+        /// <summary>
+        /// These results were aborted and require further testing. 
+        /// This can happen either because of technical restrictions to what the rule can test, or because a javascript error occurred.
+        /// </summary>
         public AxeResultItem[] Incomplete { get; }
+
+        /// <summary>
+        /// The date and time that analysis was completed.
+        /// </summary>
         public DateTimeOffset? Timestamp { get; private set; }
+
+        /// <summary>
+        /// Information about the current browser or node application that ran the audit.
+        /// </summary>
         public AxeTestEnvironment TestEnvironment { get; private set; }
+
+        /// <summary>
+        /// The runner that ran the audit.
+        /// </summary>
         public AxeTestRunner TestRunner { get; set; }
 
+        /// <summary>
+        /// The URL of the page that was tested.
+        /// </summary>
         public string Url { get; private set; }
 
         public string Error { get; private set; }
 
-
+        /// <summary>
+        /// The Name of the application that ran the audit.
+        /// </summary>
         public string TestEngineName { get; private set; }
 
+        /// <summary>
+        /// The Version of the application that ran the audit.
+        /// </summary>
         public string TestEngineVersion { get; private set; }
 
         public object ToolOptions { get; private set; }

--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// Axe results object
+    /// </summary>
     public class AxeResult
     {
         /// <summary>
@@ -47,6 +50,9 @@ namespace Deque.AxeCore.Commons
         /// </summary>
         public string Url { get; private set; }
 
+        /// <summary>
+        /// The Error that was found on the application that ran the audit.
+        /// </summary>
         public string Error { get; private set; }
 
         /// <summary>
@@ -59,6 +65,9 @@ namespace Deque.AxeCore.Commons
         /// </summary>
         public string TestEngineVersion { get; private set; }
 
+        /// <summary>
+        /// The tool options used for the configuration of the data format used by axe.
+        /// </summary>
         public object ToolOptions { get; private set; }
 
         public AxeResult(JObject result)

--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -4,7 +4,7 @@ using System;
 namespace Deque.AxeCore.Commons
 {
     /// <summary>
-    /// Axe results object
+    /// Represents the complete results of an axe scan, including results from all rules and nodes included in the scan.
     /// </summary>
     public class AxeResult
     {

--- a/packages/commons/src/AxeResultCheck.cs
+++ b/packages/commons/src/AxeResultCheck.cs
@@ -1,5 +1,8 @@
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// Axe result check
+    /// </summary>
     public class AxeResultCheck
     {
         /// <summary>

--- a/packages/commons/src/AxeResultCheck.cs
+++ b/packages/commons/src/AxeResultCheck.cs
@@ -1,7 +1,7 @@
 namespace Deque.AxeCore.Commons
 {
     /// <summary>
-    /// Axe result check
+    /// Represents the results from one specific axe check on one specific node. The results of an axe rule may be based on the results of multiple checks.
     /// </summary>
     public class AxeResultCheck
     {

--- a/packages/commons/src/AxeResultCheck.cs
+++ b/packages/commons/src/AxeResultCheck.cs
@@ -2,10 +2,29 @@ namespace Deque.AxeCore.Commons
 {
     public class AxeResultCheck
     {
+        /// <summary>
+        /// Additional information that is specific to the type of Check which is optional.
+        /// </summary>
         public object Data { get; set; }
+
+        /// <summary>
+        /// Unique Identifier for this check.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// How serious this particular check is.
+        /// </summary>
         public string Impact { get; set; }
+
+        /// <summary>
+        /// Description of why this check passed or failed.
+        /// </summary>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Array of information about other nodes that are related to this check.
+        /// </summary>
         public AxeResultRelatedNode[] RelatedNodes { get; set; }
     }
 }

--- a/packages/commons/src/AxeResultItem.cs
+++ b/packages/commons/src/AxeResultItem.cs
@@ -2,12 +2,39 @@ namespace Deque.AxeCore.Commons
 {
     public class AxeResultItem
     {
+        /// <summary>
+        /// Unique Identifier for the rule.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Text string that describes what the rule does.
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// Help text that describes the test that was performed.
+        /// </summary>
         public string Help { get; set; }
+
+        /// <summary>
+        /// URL that provides more information about the specifics of the violation. Links to a page on the Deque University site.
+        /// </summary>
         public string HelpUrl { get; set; }
+
+        /// <summary>
+        /// How serious the violation is.
+        /// </summary>
         public string Impact { get; set; }
+
+        /// <summary>
+        /// Array of tags that this rule is assigned.
+        /// </summary>
         public string[] Tags { get; set; }
+
+        /// <summary>
+        /// List of all elements the Rule tested.
+        /// </summary>
         public AxeResultNode[] Nodes { get; set; }
     }
 }

--- a/packages/commons/src/AxeResultItem.cs
+++ b/packages/commons/src/AxeResultItem.cs
@@ -1,5 +1,8 @@
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// Axe results object item
+    /// </summary>
     public class AxeResultItem
     {
         /// <summary>

--- a/packages/commons/src/AxeResultItem.cs
+++ b/packages/commons/src/AxeResultItem.cs
@@ -1,7 +1,7 @@
 namespace Deque.AxeCore.Commons
 {
     /// <summary>
-    /// Axe results object item
+    /// Represents the results from one specific axe rule across all the nodes from an axe scan.
     /// </summary>
     public class AxeResultItem
     {
@@ -36,7 +36,7 @@ namespace Deque.AxeCore.Commons
         public string[] Tags { get; set; }
 
         /// <summary>
-        /// List of all elements the Rule tested.
+        /// List of all elements the Rule evaluated to the same result for.
         /// </summary>
         public AxeResultNode[] Nodes { get; set; }
     }

--- a/packages/commons/src/AxeResultNode.cs
+++ b/packages/commons/src/AxeResultNode.cs
@@ -3,16 +3,50 @@ using System.Collections.Generic;
 
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// A tested rule element.
+    /// </summary>
     public class AxeResultNode
     {
+        /// <summary>
+        /// Target identifier of this result node.
+        /// </summary>
         [JsonProperty("target", ItemConverterType = typeof(AxeResultTargetConverter), NullValueHandling = NullValueHandling.Ignore)]
         public List<AxeResultTarget> Target { get; set; }
+
+        /// <summary>
+        /// Xpath selectors for elements
+        /// </summary>
         public List<string> XPath { get; set; }
+
+        /// <summary>
+        /// Elements ancestry.
+        /// </summary>
         public List<string> Ancestry { get; set; }
+
+        /// <summary>
+        /// Snippet of HTML of the Element.
+        /// </summary>
         public string Html { get; set; }
+
+        /// <summary>
+        /// How serious the violation is.
+        /// </summary>
         public string Impact { get; set; }
+
+        /// <summary>
+        /// List of checks that were made where at least one must have passed.
+        /// </summary>
         public AxeResultCheck[] Any { get; set; }
+
+        /// <summary>
+        /// List of checks that were made where all must have passed.
+        /// </summary>
         public AxeResultCheck[] All { get; set; }
+
+        /// <summary>
+        /// List of checks that were made where all must have not passed.
+        /// </summary>
         public AxeResultCheck[] None { get; set; }
     }
 }

--- a/packages/commons/src/AxeResultRelatedNode.cs
+++ b/packages/commons/src/AxeResultRelatedNode.cs
@@ -3,10 +3,19 @@ using System.Collections.Generic;
 
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// Information about other nodes related to a check.
+    /// </summary>
     public class AxeResultRelatedNode
     {
+        /// <summary>
+        /// HTML source of the related node.
+        /// </summary>
         public string Html { get; set; }
 
+        /// <summary>
+        /// List of selectors for the related node.
+        /// </summary>
         [JsonProperty("target", ItemConverterType = typeof(AxeResultTargetConverter), NullValueHandling = NullValueHandling.Ignore)]
         public List<AxeResultTarget> Target { get; set; }
     }

--- a/packages/commons/src/AxeRunContext.cs
+++ b/packages/commons/src/AxeRunContext.cs
@@ -9,8 +9,20 @@ namespace Deque.AxeCore.Commons
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class AxeRunContext
     {
+        /// <summary>
+        /// List of items to include.
+        /// If not specified it includes the entire document by default.
+        /// The last string items in the array will be the CSS selector,
+        /// the preceding items are specifying nested frames.
+        /// </summary>
         [JsonProperty("include")]
         public List<string[]> Include { get; set; }
+
+        /// <summary>
+        /// List of items to exclude.
+        /// The last string items in the array will be the CSS selector,
+        /// the preceding items are specifying nested frames.
+        /// </summary>
         [JsonProperty("exclude")]
         public List<string[]> Exclude { get; set; }
     }

--- a/packages/commons/src/AxeTestEnvironment.cs
+++ b/packages/commons/src/AxeTestEnvironment.cs
@@ -1,11 +1,33 @@
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// Information about the current browser or node application that ran the audit.
+    /// </summary>
     public class AxeTestEnvironment
     {
+        /// <summary>
+        /// User Agent
+        /// </summary>
         public string UserAgent { get; set; }
+
+        /// <summary>
+        /// Window Width.
+        /// </summary>
         public int WindowWidth { get; set; }
+
+        /// <summary>
+        /// Window Height.
+        /// </summary>
         public int WindowHeight { get; set; }
+
+        /// <summary>
+        /// Orientation Type.
+        /// </summary>
         public string OrientationType { get; set; }
+
+        /// <summary>
+        /// Orientation Angle.
+        /// </summary>
         public double? OrientationAngle { get; set; }
     }
 }

--- a/packages/commons/src/AxeTestEnvironment.cs
+++ b/packages/commons/src/AxeTestEnvironment.cs
@@ -11,12 +11,12 @@ namespace Deque.AxeCore.Commons
         public string UserAgent { get; set; }
 
         /// <summary>
-        /// Window Width.
+        /// Window Width in pixels.
         /// </summary>
         public int WindowWidth { get; set; }
 
         /// <summary>
-        /// Window Height.
+        /// Window Height in pixels.
         /// </summary>
         public int WindowHeight { get; set; }
 
@@ -26,7 +26,7 @@ namespace Deque.AxeCore.Commons
         public string OrientationType { get; set; }
 
         /// <summary>
-        /// Orientation Angle.
+        /// Orientation Angle in degrees.
         /// </summary>
         public double? OrientationAngle { get; set; }
     }

--- a/packages/commons/src/AxeTestRunner.cs
+++ b/packages/commons/src/AxeTestRunner.cs
@@ -1,7 +1,13 @@
 namespace Deque.AxeCore.Commons
 {
+    /// <summary>
+    /// Axe Test Runner
+    /// </summary>
     public class AxeTestRunner
     {
+        /// <summary>
+        /// Test Runner Name
+        /// </summary>
         public string Name { get; set; }
     }
 }


### PR DESCRIPTION
## Details
<!-- Provide a sentence or two describing what the PR changes -->
This PR adds comments to the public types in commons package. Most of the descriptions were taken from the [axe API documentation](https://www.deque.com/axe/core-documentation/api-documentation/).

Other references: 
* WindowWidth: https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth
* WindowHeight: https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight
* OrientationAngle: https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/angle and https://w3c.github.io/screen-orientation/#dom-screenorientation-angle

Closes Issue: #18 
Closes Issue: #60 