### PR TITLE
chore: enable .NET code analysis checks for all projects

### DIFF
--- a/packages/commons/src/.editorconfig
+++ b/packages/commons/src/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+# Requires the use of ConfigureAwait when awaiting tasks
+# See https://devblogs.microsoft.com/dotnet/configureawait-faq/
+dotnet_diagnostic.CA2007.severity = error

--- a/packages/commons/src/Deque.AxeCore.Commons.csproj
+++ b/packages/commons/src/Deque.AxeCore.Commons.csproj
@@ -16,6 +16,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
     <!-- Do not update this by-hand; updates are automated via the create-release workflow -->
     <VersionPrefix>4.4.0</VersionPrefix>

--- a/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
+++ b/packages/commons/test/Deque.AxeCore.Commons.Test.csproj
@@ -7,6 +7,7 @@
     -->
     <TargetFrameworks>net471;netcoreapp3.1;net6.0</TargetFrameworks>
 
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/packages/playwright/src/.editorconfig
+++ b/packages/playwright/src/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+# Requires the use of ConfigureAwait when awaiting tasks
+# See https://devblogs.microsoft.com/dotnet/configureawait-faq/
+dotnet_diagnostic.CA2007.severity = error

--- a/packages/playwright/src/AxeContent/DefaultAxeContentEmbedder.cs
+++ b/packages/playwright/src/AxeContent/DefaultAxeContentEmbedder.cs
@@ -28,12 +28,12 @@ namespace Deque.AxeCore.Playwright.AxeContent
             {
                 foreach (IFrame frame in page.Frames)
                 {
-                    await frame.EvaluateAsync($"() => {axeCoreScriptContent}");
+                    await frame.EvaluateAsync($"() => {axeCoreScriptContent}").ConfigureAwait(false);
                 }
             }
             else
             {
-                await page.EvaluateAsync($"() => {axeCoreScriptContent}");
+                await page.EvaluateAsync($"() => {axeCoreScriptContent}").ConfigureAwait(false);
             }
         }
     }

--- a/packages/playwright/src/AxeCoreWrapper/DefaultAxeCoreWrapper.cs
+++ b/packages/playwright/src/AxeCoreWrapper/DefaultAxeCoreWrapper.cs
@@ -39,18 +39,18 @@ namespace Deque.AxeCore.Playwright.AxeCoreWrapper
         /// <inheritdoc/>
         public async Task<IList<AxeRuleMetadata>> GetRules(IPage page, IList<string>? tags = null)
         {
-            await m_axeContentEmbedder.EmbedAxeCoreIntoPage(page, false);
+            await m_axeContentEmbedder.EmbedAxeCoreIntoPage(page, false).ConfigureAwait(false);
 
-            object jsonObject = await page.EvaluateAsync<object>("(paramTags) => window.axe.getRules(paramTags)", tags);
+            object jsonObject = await page.EvaluateAsync<object>("(paramTags) => window.axe.getRules(paramTags)", tags).ConfigureAwait(false);
             return DeserializeRuleMetadata(jsonObject);
         }
 
         /// <inheritdoc/>
         public async Task<AxeResult> Run(IPage page, AxeRunContext? context = null, AxeRunOptions? options = null)
         {
-            await m_axeContentEmbedder.EmbedAxeCoreIntoPage(page, options?.Iframes);
+            await m_axeContentEmbedder.EmbedAxeCoreIntoPage(page, options?.Iframes).ConfigureAwait(false);
 
-            AxeResult axeResult = await EvaluateAxeRun(page, context, options);
+            AxeResult axeResult = await EvaluateAxeRun(page, context, options).ConfigureAwait(false);
 
             return axeResult;
         }
@@ -58,12 +58,12 @@ namespace Deque.AxeCore.Playwright.AxeCoreWrapper
         /// <inheritdoc/>
         public async Task<AxeResult> RunOnLocator(ILocator locator, AxeRunOptions? options = null)
         {
-            await m_axeContentEmbedder.EmbedAxeCoreIntoPage(locator.Page, options?.Iframes);
+            await m_axeContentEmbedder.EmbedAxeCoreIntoPage(locator.Page, options?.Iframes).ConfigureAwait(false);
 
             string paramString = JsonConvert.SerializeObject(options);
             string runParamTemplate = options != null ? "JSON.parse(runOptions)" : string.Empty;
 
-            object jsonObject = await locator.EvaluateAsync<object>($"(node, runOptions) => window.axe.run(node, {runParamTemplate})", paramString);
+            object jsonObject = await locator.EvaluateAsync<object>($"(node, runOptions) => window.axe.run(node, {runParamTemplate})", paramString).ConfigureAwait(false);
             return DeserializeResult(jsonObject);
         }
 
@@ -75,7 +75,7 @@ namespace Deque.AxeCore.Playwright.AxeCoreWrapper
 
             string? contextParam = context is null ? string.Empty : ($"JSON.parse(\'{JsonConvert.SerializeObject(context)}\'),");
 
-            object jsonObject = await page.EvaluateAsync<object>($"(runOptions) => window.axe.run({contextParam}{runParamTemplate})", paramString);
+            object jsonObject = await page.EvaluateAsync<object>($"(runOptions) => window.axe.run({contextParam}{runParamTemplate})", paramString).ConfigureAwait(false);
 
             return DeserializeResult(jsonObject);
         }

--- a/packages/playwright/src/Deque.AxeCore.Playwright.csproj
+++ b/packages/playwright/src/Deque.AxeCore.Playwright.csproj
@@ -17,6 +17,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
     <!-- override this in official/release build/pack/publish commands with -p:Version=x.y.z -->
     <VersionPrefix>4.4.0</VersionPrefix>

--- a/packages/playwright/src/LocatorExtensions.cs
+++ b/packages/playwright/src/LocatorExtensions.cs
@@ -26,7 +26,7 @@ namespace Deque.AxeCore.Playwright
 
             IAxeCoreWrapper axeCoreWrapper = new DefaultAxeCoreWrapper(axeContentEmbedder);
 
-            return await axeCoreWrapper.RunOnLocator(locator, options);
+            return await axeCoreWrapper.RunOnLocator(locator, options).ConfigureAwait(false);
         }
     }
 }

--- a/packages/playwright/src/PageExtensions.cs
+++ b/packages/playwright/src/PageExtensions.cs
@@ -29,7 +29,7 @@ namespace Deque.AxeCore.Playwright
 
             IAxeCoreWrapper axeCoreWrapper = new DefaultAxeCoreWrapper(axeContentEmbedder);
 
-            return await axeCoreWrapper.GetRules(page, tags);
+            return await axeCoreWrapper.GetRules(page, tags).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Deque.AxeCore.Playwright
         /// <returns>The AxeResult</returns>
         public static async Task<AxeResult> RunAxe(this IPage page, AxeRunOptions? options = null)
         {
-            return await RunAxeInner(page, null, options);
+            return await RunAxeInner(page, null, options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Deque.AxeCore.Playwright
             AxeRunContext context,
             AxeRunOptions? options = null)
         {
-            return await RunAxeInner(page, context, options);
+            return await RunAxeInner(page, context, options).ConfigureAwait(false);
         }
 
         private static async Task<AxeResult> RunAxeInner(this IPage page, AxeRunContext? context, AxeRunOptions? options)
@@ -65,7 +65,7 @@ namespace Deque.AxeCore.Playwright
 
             IAxeCoreWrapper axeCoreWrapper = new DefaultAxeCoreWrapper(axeContentEmbedder);
 
-            AxeResult results = await axeCoreWrapper.Run(page, context, options);
+            AxeResult results = await axeCoreWrapper.Run(page, context, options).ConfigureAwait(false);
             IFileSystem fileSystem = new FileSystem();
 
             return results;

--- a/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
+++ b/packages/playwright/test/Deque.AxeCore.Playwright.Test.csproj
@@ -7,6 +7,7 @@
     -->
     <TargetFrameworks>net6.0</TargetFrameworks>
 
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/packages/selenium/src/.editorconfig
+++ b/packages/selenium/src/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+# Requires the use of ConfigureAwait when awaiting tasks
+# See https://devblogs.microsoft.com/dotnet/configureawait-faq/
+dotnet_diagnostic.CA2007.severity = error

--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -296,11 +296,11 @@ namespace Deque.AxeCore.Selenium
                 // array of object, not an array of strings.
                 partialResults.Add(JsonConvert.DeserializeObject<object>(partialRes));
             }
-            catch (Exception ex)
+            catch
             {
                 if (isTopLevel)
                 {
-                    throw ex;
+                    throw;
                 }
                 else
                 {

--- a/packages/selenium/src/Deque.AxeCore.Selenium.csproj
+++ b/packages/selenium/src/Deque.AxeCore.Selenium.csproj
@@ -16,6 +16,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
     <!-- Do not update this by-hand; updates are automated via the create-release workflow -->
     <VersionPrefix>4.4.0</VersionPrefix>

--- a/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
+++ b/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
@@ -7,6 +7,7 @@
     -->
     <TargetFrameworks>net471;netcoreapp3.1;net6.0</TargetFrameworks>
 
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Details
This PR is a follow-up to a review comment from #64. It enables the built-in .NET SDK code analyzers on all projects in the repo, with:

* Default ruleset enabled in all projects
* Rule [CA2007](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007) enabled in library projects, to enforce the recommendation from [the ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/) and maintain consistency with the Task behavior that Playwright itself uses

It resolves all pre-existing violations of these issues, but will create some semantic merge conflicts with #64 (which introduces several new `await` points that will need `ConfigureAwait(false)`) - FYI @AdnoC 