### PR TITLE
chore: correct outdated comment in Playwright csproj

### DIFF
--- a/packages/playwright/src/Deque.AxeCore.Playwright.csproj
+++ b/packages/playwright/src/Deque.AxeCore.Playwright.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Authors>Deque</Authors>
     <Description>Automated accessibility testing via axe for tests written with Microsoft Playwright .NET</Description>
@@ -18,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <!-- override this in official/release build/pack/publish commands with -p:Version=x.y.z -->
+    <!-- Do not update this by-hand; updates are automated via the create-release workflow -->
     <VersionPrefix>4.4.0</VersionPrefix>
     <VersionSuffix>development</VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
## Details
#39 modified the versioning strategy for the assorted packages such that a comment in `Deque.AxeCore.Playwright.csproj` became outdated, but missed updating the comment. This PR corrects the comment to match the actual versioning expectations, consistent with the other .csproj files.
