### PR TITLE
feat(selenium): fix default value and add API docs for new UseLegacyMode API

### DIFF
--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -311,7 +311,7 @@ AxeBuilderOptions axeBuilderOptions = new AxeBuilderOptions
 AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 ```
 
-### `AxeBuilder.UseLegacyMode(boolean legacyMode)`
+### `AxeBuilder.UseLegacyMode(boolean legacyMode = true)`
 
 Set the frame testing method to "legacy mode". In this mode, axe will not open a blank page in which to aggregate its results. This can be used in an environment where opening a blank page is causes issues.
 

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -313,7 +313,7 @@ AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 
 ### `AxeBuilder.UseLegacyMode(boolean legacyMode = true)`
 
-Set the frame testing method to "legacy mode". In this mode, axe will not open a blank page in which to aggregate its results. This can be used in an environment where opening a blank page is causes issues.
+Set the frame testing method to "legacy mode". In this mode, axe will not open a blank page in which to aggregate its results. This can be used in an environment where opening a blank page causes issues.
 
 With legacy mode turned on, axe will fall back to its test solution prior to the 4.3 release, but with cross-origin frame testing disabled. The frame-tested rule will report which frames were untested.
 

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -311,6 +311,20 @@ AxeBuilderOptions axeBuilderOptions = new AxeBuilderOptions
 AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 ```
 
+### `AxeBuilder.UseLegacyMode(boolean legacyMode)`
+
+Set the frame testing method to "legacy mode". In this mode, axe will not open a blank page in which to aggregate its results. This can be used in an environment where opening a blank page is causes issues.
+
+With legacy mode turned on, axe will fall back to its test solution prior to the 4.3 release, but with cross-origin frame testing disabled. The frame-tested rule will report which frames were untested.
+
+**Important**: Use of `.UseLegacyMode()` is a last resort. If you find there is no other solution, please [report this as an issue](https://github.com/dequelabs/axe-core-nuget/issues/). It will be removed in a future release.
+
+```csharp
+AxeResult axeResult = new AxeBuilder(webDriver)
+    .UseLegacyMode()
+    .Analyze();
+```
+
 ## Working with AxeResult objects
 
 In most cases, you would run an axe scan from within a test method in a suite of end to end tests, and you would want to use a test assertion to verify that there are no unexpected accessibility violations in a page or component.

--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -69,9 +69,9 @@ namespace Deque.AxeCore.Selenium
         /// axe.finishRun() which is called in a blank page. This uses axe.run() instead,
         /// but with the restriction that cross-origin frames will not be tested.
         /// </summary>
-        /// <param name="legacyMode"></param>
+        /// <param name="legacyMode">Whether to enable or disable Legacy Mode</param>
         [Obsolete("Legacy Mode is being removed in the future. Use with caution!")]
-        public AxeBuilder UseLegacyMode(bool legacyMode = false)
+        public AxeBuilder UseLegacyMode(bool legacyMode = true)
         {
             this.useLegacyMode = legacyMode;
             return this;
@@ -81,7 +81,7 @@ namespace Deque.AxeCore.Selenium
         ///  Run configuration data that is passed to axe for scanning the web page.
         ///  This will override the value set by <see cref="WithRules(string[])"/>, <see cref="WithTags(string[])"/> & <see cref="DisableRules(string[])"/>
         /// </summary>
-        /// <param name="runOptions">run options to be used for scanning. </param>
+        /// <param name="runOptions">run options to be used for scanning</param>
         public AxeBuilder WithOptions(AxeRunOptions runOptions)
         {
             ValidateNotNullParameter(runOptions, nameof(runOptions));


### PR DESCRIPTION
## Details
This PR adds API documentation for the new public `UseLegacyMode` API to the README docs for the selenium package. The docs are based on the similar docs for [`@axe-core/playwright`'s `setLegacyMode` API](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright#axebuildersetlegacymodelegacymode-boolean--true).

While I was writing the code sample for the docs, I noticed that the default value for the new API (previously `false`) made for the following confusing behavior:

```csharp
// Looks intuitively like it would be using legacy mode, but actually isn't
AxeResult axeResult = new AxeBuilder(webDriver)
    .UseLegacyMode()
    .Analyze();
```

This PR updates the default value on `UseLegacyMode`'s parameter to `true` to make this interaction less confusing and for consistency with the `@axe-core/playwright` behavior.

Follow-up to #61 / #15 