### PR TITLE
feat(commons): add AxeTestEngine

### DIFF
--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -56,14 +56,9 @@ namespace Deque.AxeCore.Commons
         public string Error { get; private set; }
 
         /// <summary>
-        /// The Name of the application that ran the audit.
+        /// The application that ran the audit.
         /// </summary>
-        public string TestEngineName { get; private set; }
-
-        /// <summary>
-        /// The Version of the application that ran the audit.
-        /// </summary>
-        public string TestEngineVersion { get; private set; }
+        public AxeTestEngine TestEngine { get; private set; }
 
         /// <summary>
         /// The tool options used for the configuration of the data format used by axe.
@@ -81,8 +76,7 @@ namespace Deque.AxeCore.Commons
             JToken testEnvironment = result.SelectToken("testEnvironment");
             JToken testRunner = result.SelectToken("testRunner");
             JToken testEngine = result.SelectToken("testEngine");
-            JToken testEngineName = testEngine?.SelectToken("name");
-            JToken testEngineVersion = testEngine?.SelectToken("version");
+
             JToken toolOptions = result?.SelectToken("toolOptions");
             JToken error = result.SelectToken("error");
 
@@ -95,8 +89,7 @@ namespace Deque.AxeCore.Commons
             TestRunner = testRunner?.ToObject<AxeTestRunner>();
             Url = urlToken?.ToObject<string>();
             Error = error?.ToObject<string>();
-            TestEngineName = testEngineName?.ToObject<string>();
-            TestEngineVersion = testEngineVersion?.ToObject<string>();
+            TestEngine = testEngine?.ToObject<AxeTestEngine>();
             ToolOptions = toolOptions?.ToObject<object>();
         }
     }

--- a/packages/commons/src/AxeTestEngine.cs
+++ b/packages/commons/src/AxeTestEngine.cs
@@ -1,0 +1,19 @@
+namespace Deque.AxeCore.Commons
+{
+    /// <summary>
+    /// The application that ran the audit
+    /// </summary>
+    public class AxeTestEngine
+    {
+        /// <summary>
+        /// The Name of the application that ran the audit.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The Version of the application that ran the audit.
+        /// </summary>
+        public string Version { get; set; }
+    }
+}
+

--- a/packages/commons/test/AxeResultTest.cs
+++ b/packages/commons/test/AxeResultTest.cs
@@ -98,8 +98,8 @@ namespace Deque.AxeCore.Commons.Test
         {
             var result = new AxeResult(JObject.FromObject(JsonConvert.DeserializeObject(basicAxeResultJson)));
 
-            result.TestEngineName.Should().Be("axe-core");
-            result.TestEngineVersion.Should().Be("4.4.1");
+            result.TestEngine.Name.Should().Be("axe-core");
+            result.TestEngine.Version.Should().Be("4.4.1");
             result.TestRunner.Name.Should().Be("axe");
             result.TestEnvironment.UserAgent.Should().Be("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36");
             result.TestEnvironment.WindowWidth.Should().Be(800);

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -373,6 +373,7 @@ Finally, there are a few minor breaking changes which won't impact most `Seleniu
 
 1. The `.Target` and `.XPath` properties of `AxeResultNode` or `AxeResultRelatedNode` are now strongly-typed `AxeSelector` objects. Most `Selenium.Axe` users do not refer to these properties explicitly, but if your tests do, you will probably want to do so via their `ToString()` representations.
 1. `AxeRunOptions.FrameWaitTimeInMilliseconds` was renamed to `AxeRunOptions.FrameWaitTime` to match the equivalent `axe-core` API. The usage is unchanged; it still represents a value in milliseconds.
+1. `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` were replaced by a separate `AxeTestEngine` object containing `Name` and `Version` properties. You will have to replace usages of `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` with `AxeResult.TestEngine.Name` and `AxeResult.TestEngine.Version`, respectively.
 1. The already-deprecated `AxeBuilder.Options` property was removed; replace it with `WithOptions`, `WithRules`, `WithTags`, and/or `DisableRules`.
 1. The `AxeBuilder.Include` and `AxeBuilder.Exclude` overloads which accept more than one parameter have changed:
     * If you were using it to refer to an element inside a nested frame, replace it with the `Include`/`Exclude` overloads which accept an `AxeSelector`:

--- a/packages/selenium/test/RunPartial/AnalyzeTests.cs
+++ b/packages/selenium/test/RunPartial/AnalyzeTests.cs
@@ -69,8 +69,8 @@ namespace Deque.AxeCore.Selenium.Test.RunPartial
                 .Analyze();
 
             Assert.IsNotNull(res);
-            Assert.IsNotEmpty(res.TestEngineName);
-            Assert.IsNotEmpty(res.TestEngineVersion);
+            Assert.IsNotEmpty(res.TestEngine.Name);
+            Assert.IsNotEmpty(res.TestEngine.Version);
             Assert.IsNotNull(res.TestEnvironment);
             Assert.IsNotNull(res.TestEnvironment.OrientationAngle);
             Assert.IsNotEmpty(res.TestEnvironment.OrientationType);

--- a/packages/selenium/test/RunPartial/FinishRunTests.cs
+++ b/packages/selenium/test/RunPartial/FinishRunTests.cs
@@ -30,7 +30,7 @@ namespace Deque.AxeCore.Selenium.Test.RunPartial
             var legacyResults = new AxeBuilder(WebDriver, CustomSource($"{axeSource}{axeForceLegacy}"))
                 .Analyze();
 
-            Assert.That(legacyResults.TestEngineName, Is.EqualTo("axe-legacy"));
+            Assert.That(legacyResults.TestEngine.Name, Is.EqualTo("axe-legacy"));
 
 
             GoToFixture("nested-iframes.html");
@@ -62,7 +62,7 @@ namespace Deque.AxeCore.Selenium.Test.RunPartial
             Assert.That(ToJson(legacyResults.TestRunner), Is.EqualTo(ToJson(runPartialResults.TestRunner)));
             Assert.That(ToJson(legacyResults.Url), Is.EqualTo(ToJson(runPartialResults.Url)));
             Assert.That(ToJson(legacyResults.Error), Is.EqualTo(ToJson(runPartialResults.Error)));
-            Assert.That(ToJson(legacyResults.TestEngineVersion), Is.EqualTo(ToJson(runPartialResults.TestEngineVersion)));
+            Assert.That(ToJson(legacyResults.TestEngine.Version), Is.EqualTo(ToJson(runPartialResults.TestEngine.Version)));
             Assert.That(ToJson(legacyResults.ToolOptions), Is.EqualTo(ToJson(runPartialResults.ToolOptions)));
         }
 


### PR DESCRIPTION
## Details
<!-- Provide a sentence or two describing what the PR changes -->
`AxeResult` currently contains `TestEngineName` and `TestEngineVersion` properties. This PR creates an AxeTestEngine class to better represent the structure of the Axe results data, which looks like
```
"testEngine": {
    "name": "axe-core",
    "version": "3.4.1"
}
```
Closes Issue: n/a