### PR TITLE
docs: adding Playwright migration guide

### DIFF
--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -207,27 +207,26 @@ This project acts as a drop-in replacement for most of the functionality from `P
 1. Update all `using Playwright.Axe;` statements in your tests to `using Deque.AxeCore.Playwright;` and/or `using Deque.AxeCore.Commons;`
 
 There are a few minor breaking changes which won't impact most `Playwright.Axe` users, but which may require updates if you use certain advanced features:
-1. The `.Target` and `.XPath` properties of `AxeResultNode` or `AxeResultRelatedNode` are now strongly-typed `AxeSelector` objects. Most `Selenium.Axe` users do not refer to these properties explicitly, but if your tests do, you will probably want to do so via their `ToString()` representations.
-1. `AxeRunOptions.FrameWaitTimeInMilliseconds` was renamed to `AxeRunOptions.FrameWaitTime` to match the equivalent `axe-core` API. The usage is unchanged; it still represents a value in milliseconds.
+
 1. `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` were replaced by a separate `AxeTestEngine` object containing `Name` and `Version` properties. You will have to replace usages of `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` with `AxeResult.TestEngine.Name` and `AxeResult.TestEngine.Version`, respectively.
 1. `AxeRunSerialContext` has been replaced by `AxeRunContext` and `AxeSelector` types. Here are some examples of how to use the new types: 
        ```cs
-       //including/excluding an element in a child frame
-       new AxeRunContext()
-            {
-                Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
-                Exclude = new List<AxeSelector> {},
-            };
-    
-       //including/excluding elements in the main frame
+       //finding a single element using the Playwright Locator API
+        ILocator locator = page.GetByRole("menu").RunAxe();
+        
+        //including/excluding elements in the main frame
        new AxeRunContext()
             {
                 Include = new List<AxeSelector> { new AxeSelector("#foo") },
                 Exclude = new List<AxeSelector> {},
             };
-    
-       //finding a single element using the Playwright Locator API
-        ILocator locator = page.GetByRole("menu").RunAxe();
+
+        //including/excluding an element in a child frame
+       new AxeRunContext()
+            {
+                Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
+                Exclude = new List<AxeSelector> {},
+            };
         ```
 
 ## Contributing

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -206,18 +206,18 @@ This project acts as a drop-in replacement for most of the functionality from `P
 1. Add a new `<PackageReference>` to `Deque.AxeCore.Commons` at the same version number as `Deque.AxeCore.Playwright`
 1. Update all `using Playwright.Axe;` statements in your tests to `using Deque.AxeCore.Playwright;` and/or `using Deque.AxeCore.Commons;`
 
-In a move to standardize, we migrated this package away from Playwright specific typings, instead opting to use the typings from the `Deque.AxeCore.Commons` package instead. The result is a few minor breaking changes that may require updates:
-
-### Additions
-1. Added `Ancestry` to `AxeResultNode` and `AxeRunOptions`
-1. Added `Selectors` and `PingWaitTime` to `AxeRunOptions`
-
-### Removals
-1. Removed `AxeEnvironmentData` interface and using the existing environment data info in `Deque.AxeCore.Commons.AxeResult`
-1. Removed `AxeImpactValue` and `AxeRunOnlyType` enums in favor of using `string` in the Commons typings (`AxeResultItem.cs` and `AxeRunOptions.cs`, respectively)
+In a move to standardize, we migrated this package away from Playwright specific typings, instead opting to use the typings from the `Deque.AxeCore.Commons` package instead. The result is several minor breaking changes that may require updates to your code:
 ### Replacements/Renamings
-1. `AxeResults` has now been renamed to `AxeResult`; the previously used `AxeResult` for this package will now be `AxeResultItem`
-1. `AxeRunSerialContext` has been replaced by `AxeRunContext` and `AxeSelector` types. Here are some examples of how to use the new types: 
+1. `AxeResults` has now been renamed to `AxeResult`; the previously used `AxeResult` for this package will now be `AxeResultItem`.
+1. `AxeNodeResult` has been replaced with `AxeResultNode`
+1. `AxeCheckResult` has been replaced with `AxeResultCheck`
+1. `AxeRelatedNode` has been replaced with `AxeResultRelatedNode`
+1. `AxeResultGroup` has been replaced with `ResultType`
+1. `AxeRuleObjectValue` has been replaced with `RuleOptions`
+1. `AxeRunOnly` has been replaced with `RunOnlyOptions`
+1. `AxeResultRelatedNode` is now used in lieu of `AxeRelatedNode`. With this type, the Targets property is changed from a `IList<string>` to a `List<AxeResultTarget>`; users should expect to modify usages of the Targets property to include a `.ToString()` method call.
+1. `AxeRunSerialContext` has been replaced by `AxeRunContext` and `AxeSelector` types. Here are some examples of how to use the new types:
+ 
        ```cs
        //finding a single element using the Playwright Locator API
         ILocator locator = page.GetByRole("menu").RunAxe();
@@ -237,6 +237,16 @@ In a move to standardize, we migrated this package away from Playwright specific
             };
         ```
 
+### Type Modifications
+1. The Timestamp type in `AxeResult` changed from System.DateTime to System.DateTimeOffset
+1. The url type in `AxeResult` changed from Uri to string
+1. The `OrientationAngle` type in `AxeTestEnvironment` changed from int to double
+1. The `HelpUrl` in `AxeResultItem` changed from Uri to string
+### Removals
+1. Removed `AxeEnvironmentData` interface and using the existing environment data info in `Deque.AxeCore.Commons.AxeResult`
+1. Removed `AxeImpactValue` and `AxeRunOnlyType` enums in favor of using `string` in the Commons typings (`AxeResultItem.cs` and `AxeRunOptions.cs`, respectively)
+1. `FailureSummary` was removed from `AxeResultNode` (formerly `AxeNodeResult`)
+1. `ElementRef` and `PerformanceTimer` were removed from `AxeRunOptions`
 ## Contributing
 
 Refer to the general [axe-core-nuget CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -206,9 +206,17 @@ This project acts as a drop-in replacement for most of the functionality from `P
 1. Add a new `<PackageReference>` to `Deque.AxeCore.Commons` at the same version number as `Deque.AxeCore.Playwright`
 1. Update all `using Playwright.Axe;` statements in your tests to `using Deque.AxeCore.Playwright;` and/or `using Deque.AxeCore.Commons;`
 
-There are a few minor breaking changes which won't impact most `Playwright.Axe` users, but which may require updates if you use certain advanced features:
+In a move to standardize, we migrated this package away from Playwright specific typings, instead opting to use the typings from the `Deque.AxeCore.Commons` package instead. The result is a few minor breaking changes that may require updates:
 
-1. `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` were replaced by a separate `AxeTestEngine` object containing `Name` and `Version` properties. You will have to replace usages of `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` with `AxeResult.TestEngine.Name` and `AxeResult.TestEngine.Version`, respectively.
+### Additions
+1. Added `Ancestry` to `AxeResultNode` and `AxeRunOptions`
+1. Added `Selectors` and `PingWaitTime` to `AxeRunOptions`
+
+### Removals
+1. Removed `AxeEnvironmentData` interface and using the existing environment data info in `Deque.AxeCore.Commons.AxeResult`
+1. Removed `AxeImpactValue` and `AxeRunOnlyType` enums in favor of using `string` in the Commons typings (`AxeResultItem.cs` and `AxeRunOptions.cs`, respectively)
+### Replacements/Renamings
+1. `AxeResults` has now been renamed to `AxeResult`; the previously used `AxeResult` for this package will now be `AxeResultItem`
 1. `AxeRunSerialContext` has been replaced by `AxeRunContext` and `AxeSelector` types. Here are some examples of how to use the new types: 
        ```cs
        //finding a single element using the Playwright Locator API

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -3,7 +3,7 @@
 [![Deque.AxeCore.Playwright NuGet package](https://img.shields.io/nuget/v/Deque.AxeCore.Playwright)](https://www.nuget.org/packages/Deque.AxeCore.Selenium) 
 [![NuGet package download counter](https://img.shields.io/nuget/dt/Deque.AxeCore.Playwright)](https://www.nuget.org/packages/Deque.AxeCore.Selenium/) 
 
-Automated web accessibility testing with .NET, C#, and Playwright. Wraps the [axe-core](https://github.com/dequelabs/axe-core) accessibility scanning engine and the [Selenium.WebDriver](https://www.seleniumhq.org/) browser automation framework.
+Automated web accessibility testing with .NET, C#, and Playwright. Wraps the [axe-core](https://github.com/dequelabs/axe-core) accessibility scanning engine and the [Playwright](https://playwright.dev/dotnet/) browser automation framework.
 
 Compatible with .NET Standard 2.1.
 
@@ -198,6 +198,37 @@ axeResults = await locator.RunAxe(options);
 
 
 ```
+## Migrating from `Playwright.Axe` ([PlaywrightAxeDotnet](https://github.com/IsaacWalker/PlaywrightAxeDotnet))
+
+This project acts as a drop-in replacement for most of the functionality from `Playwright.Axe`. ([PlaywrightAxeDotnet](https://github.com/IsaacWalker/PlaywrightAxeDotnet)). To migrate:
+
+1. Update your test `.csproj` file's `<PackageReference>` for `Playwright.Axe` to `Deque.AxeCore.Playwright`
+1. Add a new `<PackageReference>` to `Deque.AxeCore.Commons` at the same version number as `Deque.AxeCore.Playwright`
+1. Update all `using Playwright.Axe;` statements in your tests to `using Deque.AxeCore.Playwright;` and/or `using Deque.AxeCore.Commons;`
+
+There are a few minor breaking changes which won't impact most `Playwright.Axe` users, but which may require updates if you use certain advanced features:
+1. The `.Target` and `.XPath` properties of `AxeResultNode` or `AxeResultRelatedNode` are now strongly-typed `AxeSelector` objects. Most `Selenium.Axe` users do not refer to these properties explicitly, but if your tests do, you will probably want to do so via their `ToString()` representations.
+1. `AxeRunOptions.FrameWaitTimeInMilliseconds` was renamed to `AxeRunOptions.FrameWaitTime` to match the equivalent `axe-core` API. The usage is unchanged; it still represents a value in milliseconds.
+1. `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` were replaced by a separate `AxeTestEngine` object containing `Name` and `Version` properties. You will have to replace usages of `AxeResult.TestEngineName` and `AxeResult.TestEngineVersion` with `AxeResult.TestEngine.Name` and `AxeResult.TestEngine.Version`, respectively.
+1. `AxeRunSerialContext` has been replaced by `AxeRunContext` and `AxeSelector` types. Here are some examples of how to use the new types: 
+       ```cs
+       //including/excluding an element in a child frame
+       new AxeRunContext()
+            {
+                Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
+                Exclude = new List<AxeSelector> {},
+            };
+    
+       //including/excluding elements in the main frame
+       new AxeRunContext()
+            {
+                Include = new List<AxeSelector> { new AxeSelector("#foo") },
+                Exclude = new List<AxeSelector> {},
+            };
+    
+       //finding a single element using the Playwright Locator API
+        ILocator locator = page.GetByRole("menu").RunAxe();
+        ```
 
 ## Contributing
 


### PR DESCRIPTION
## Details
<!-- Provide a sentence or two describing what the PR changes -->
Updates a minor typo in the README.md, instructs on how to migrate from `Playwright.axe`, and adds description of relelvant breaking changes for said migration

Closes Issue: #21 