### PR TITLE
chore: re-add release script accidentally omitted from #39

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fail on first error.
+set -e
+
+releaseLevel="$1"
+
+oldVersion="$(node -pe 'require("./package.json").version')"
+npx commit-and-tag-version@"$COMMIT_AND_TAG_VERSION_VERSION" --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
+newVersion="$(node -pe 'require("./package.json").version')"
+
+sed -i -e "s/<VersionPrefix>$oldVersion<\/VersionPrefix>/<VersionPrefix>$newVersion<\/VersionPrefix>/" ./packages/*/src/*.csproj
+
+npx conventional-changelog-cli@"$CHANGELOG_VERSION" -p angular -i CHANGELOG.md -s


### PR DESCRIPTION
## Details
This PR adds the `prepare_release.sh` script that was present in #34 and intended to be included in #39. It is invoked from L25 of the `create-release.yml` workflow that was merged as part of #39.

Closes Issue: n/a