### PR TITLE
feat: replace AxeResult.Error property with exceptions

### DIFF
--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -51,11 +51,6 @@ namespace Deque.AxeCore.Commons
         public string Url { get; private set; }
 
         /// <summary>
-        /// The Error that was found on the application that ran the audit.
-        /// </summary>
-        public string Error { get; private set; }
-
-        /// <summary>
         /// The Name of the application that ran the audit.
         /// </summary>
         public string TestEngineName { get; private set; }
@@ -72,6 +67,14 @@ namespace Deque.AxeCore.Commons
 
         public AxeResult(JObject result)
         {
+            // Some (but not all) WebDrivers treat objects with an error property as a JavaScript error
+            // and don't reach this point, but for those that don't, we handle it as an error ourselves.
+            string error = result.SelectToken("error")?.ToObject<string>();
+            if (error != null)
+            {
+                throw new Exception($"JavaScript error occurred while running axe-core in page: {error}");
+            }
+
             JToken violationsToken = result.SelectToken("violations");
             JToken passesToken = result.SelectToken("passes");
             JToken inapplicableToken = result.SelectToken("inapplicable");
@@ -84,7 +87,6 @@ namespace Deque.AxeCore.Commons
             JToken testEngineName = testEngine?.SelectToken("name");
             JToken testEngineVersion = testEngine?.SelectToken("version");
             JToken toolOptions = result?.SelectToken("toolOptions");
-            JToken error = result.SelectToken("error");
 
             Violations = violationsToken?.ToObject<AxeResultItem[]>();
             Passes = passesToken?.ToObject<AxeResultItem[]>();
@@ -94,7 +96,6 @@ namespace Deque.AxeCore.Commons
             TestEnvironment = testEnvironment?.ToObject<AxeTestEnvironment>();
             TestRunner = testRunner?.ToObject<AxeTestRunner>();
             Url = urlToken?.ToObject<string>();
-            Error = error?.ToObject<string>();
             TestEngineName = testEngineName?.ToObject<string>();
             TestEngineVersion = testEngineVersion?.ToObject<string>();
             ToolOptions = toolOptions?.ToObject<object>();

--- a/packages/commons/test/AxeResultTest.cs
+++ b/packages/commons/test/AxeResultTest.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Deque.AxeCore.Commons.Test
+{
+    [TestFixture]
+    public class AxeResultTest
+    {
+        readonly string basicAxeResultJson = @"
+{
+  ""testEngine"": {
+    ""name"": ""axe-core"",
+    ""version"": ""4.4.1""
+  },
+  ""testRunner"": {
+    ""name"": ""axe""
+  },
+  ""testEnvironment"": {
+    ""userAgent"": ""Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36"",
+    ""windowWidth"": 800,
+    ""windowHeight"": 600,
+    ""orientationAngle"": 0,
+    ""orientationType"": ""portrait-primary""
+  },
+  ""timestamp"": ""2000-01-02T03:04:05.006Z"",
+  ""url"": ""http://localhost/"",
+  ""toolOptions"": {
+    ""xpath"": true,
+    ""runOnly"": {
+      ""type"": ""rule"",
+      ""values"": [
+        ""document-title""
+      ]
+    },
+    ""reporter"": ""v1""
+  },
+  ""inapplicable"": [],
+  ""passes"": [],
+  ""incomplete"": [],
+  ""violations"": [
+    {
+      ""id"": ""document-title"",
+      ""impact"": ""serious"",
+      ""tags"": [
+        ""cat.text-alternatives"",
+        ""wcag2a"",
+        ""wcag242"",
+        ""ACT""
+      ],
+      ""description"": ""Ensures each HTML document contains a non-empty <title> element"",
+      ""help"": ""Documents must have <title> element to aid in navigation"",
+      ""helpUrl"": ""https://dequeuniversity.com/rules/axe/4.4/document-title?application=axe-puppeteer"",
+      ""nodes"": [
+        {
+          ""any"": [
+            {
+              ""id"": ""doc-has-title"",
+              ""data"": null,
+              ""relatedNodes"": [],
+              ""impact"": ""serious"",
+              ""message"": ""Document does not have a non-empty <title> element""
+            }
+          ],
+          ""all"": [],
+          ""none"": [],
+          ""impact"": ""serious"",
+          ""html"": ""<html><head></head><body>\n</body></html>"",
+          ""target"": [
+            ""html""
+          ],
+          ""xpath"": [
+            ""/html""
+          ],
+          ""failureSummary"": ""Fix any of the following:\n  Document does not have a non-empty <title> element""
+        }
+      ]
+    }
+  ]
+}
+        ";
+
+        [Test]
+        public void CtorShouldThrowExceptionForErrorProperty()
+        {
+            Assert.Throws<Exception>(() => new AxeResult(JObject.FromObject(JsonConvert.DeserializeObject(@"
+            {
+                error: ""message from JSON error property""
+            }
+            "))), "JavaScript error occurred while running axe-core in page: message from JSON error property");
+        }
+
+        [Test]
+        public void CtorShouldParseFieldsFromBasicSampleAxeResultJson()
+        {
+            var result = new AxeResult(JObject.FromObject(JsonConvert.DeserializeObject(basicAxeResultJson)));
+
+            result.TestEngineName.Should().Be("axe-core");
+            result.TestEngineVersion.Should().Be("4.4.1");
+            result.TestRunner.Name.Should().Be("axe");
+            result.TestEnvironment.UserAgent.Should().Be("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36");
+            result.TestEnvironment.WindowWidth.Should().Be(800);
+            result.TestEnvironment.WindowHeight.Should().Be(600);
+            result.TestEnvironment.OrientationAngle.Should().Be(0);
+            result.TestEnvironment.OrientationType.Should().Be("portrait-primary");
+            result.Timestamp.Should().Be(new DateTimeOffset(2000, 1, 2, 3, 4, 5, 6, TimeSpan.Zero));
+            result.Url.Should().Be("http://localhost/");
+            result.ToolOptions.ToString().Should().NotBeNullOrEmpty();
+            result.Inapplicable.Should().BeEmpty();
+            result.Passes.Should().BeEmpty();
+            result.Incomplete.Should().BeEmpty();
+            result.Violations.Should().HaveCount(1);
+
+            var violation = result.Violations.Single();
+            violation.Id.Should().Be("document-title");
+            violation.Impact.Should().Be("serious");
+            violation.Tags.Should().BeEquivalentTo("cat.text-alternatives", "wcag2a", "wcag242", "ACT");
+            violation.Description.Should().Be("Ensures each HTML document contains a non-empty <title> element");
+            violation.Help.Should().Be("Documents must have <title> element to aid in navigation");
+            violation.HelpUrl.Should().Be("https://dequeuniversity.com/rules/axe/4.4/document-title?application=axe-puppeteer");
+            violation.Nodes.Should().HaveCount(1);
+
+            var node = violation.Nodes.Single();
+            node.All.Should().BeEmpty();
+            node.None.Should().BeEmpty();
+            node.Impact.Should().Be("serious");
+            node.Html.Should().Be("<html><head></head><body>\n</body></html>");
+            node.Target.Should().Be(new AxeSelector("html"));
+            node.XPath.Should().Be(new AxeSelector("/html"));
+            node.Any.Should().HaveCount(1);
+
+            var check = node.Any.Single();
+            check.Id.Should().Be("doc-has-title");
+            check.Data.Should().BeNull();
+            check.RelatedNodes.Should().BeEmpty();
+            check.Impact.Should().Be("serious");
+            check.Message.Should().Be("Document does not have a non-empty <title> element");
+        }
+
+        [Test]
+        public void ToStringShouldBeStable()
+        {
+            var result1 = new AxeResult(JObject.FromObject(JsonConvert.DeserializeObject(basicAxeResultJson)));
+            var result2 = new AxeResult(JObject.FromObject(JsonConvert.DeserializeObject(basicAxeResultJson)));
+
+            result1.ToString().Should().Be(result2.ToString());
+        }
+    }
+}

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -374,7 +374,7 @@ Finally, there are a few minor breaking changes which won't impact most `Seleniu
 1. The `.Target` and `.XPath` properties of `AxeResultNode` or `AxeResultRelatedNode` are now strongly-typed `AxeSelector` objects. Most `Selenium.Axe` users do not refer to these properties explicitly, but if your tests do, you will probably want to do so via their `ToString()` representations.
 1. `AxeRunOptions.FrameWaitTimeInMilliseconds` was renamed to `AxeRunOptions.FrameWaitTime` to match the equivalent `axe-core` API. The usage is unchanged; it still represents a value in milliseconds.
 1. The already-deprecated `AxeBuilder.Options` property was removed; replace it with `WithOptions`, `WithRules`, `WithTags`, and/or `DisableRules`.
-1. The `AxeResult.Error` property was removed; any errors that would have appeared here are instead be reported as exceptions.
+1. The `AxeResult.Error` property was removed; any errors that would have appeared here are instead reported as exceptions.
 1. The `AxeBuilder.Include` and `AxeBuilder.Exclude` overloads which accept more than one parameter have changed:
     * If you were using it to refer to an element inside a nested frame, replace it with the `Include`/`Exclude` overloads which accept an `AxeSelector`:
         ```cs

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -374,6 +374,7 @@ Finally, there are a few minor breaking changes which won't impact most `Seleniu
 1. The `.Target` and `.XPath` properties of `AxeResultNode` or `AxeResultRelatedNode` are now strongly-typed `AxeSelector` objects. Most `Selenium.Axe` users do not refer to these properties explicitly, but if your tests do, you will probably want to do so via their `ToString()` representations.
 1. `AxeRunOptions.FrameWaitTimeInMilliseconds` was renamed to `AxeRunOptions.FrameWaitTime` to match the equivalent `axe-core` API. The usage is unchanged; it still represents a value in milliseconds.
 1. The already-deprecated `AxeBuilder.Options` property was removed; replace it with `WithOptions`, `WithRules`, `WithTags`, and/or `DisableRules`.
+1. The `AxeResult.Error` property was removed; any errors that would have appeared here are instead be reported as exceptions.
 1. The `AxeBuilder.Include` and `AxeBuilder.Exclude` overloads which accept more than one parameter have changed:
     * If you were using it to refer to an element inside a nested frame, replace it with the `Include`/`Exclude` overloads which accept an `AxeSelector`:
         ```cs

--- a/packages/selenium/test/RunPartial/FinishRunTests.cs
+++ b/packages/selenium/test/RunPartial/FinishRunTests.cs
@@ -61,7 +61,6 @@ namespace Deque.AxeCore.Selenium.Test.RunPartial
             Assert.That(ToJson(legacyResults.TestEnvironment), Is.EqualTo(ToJson(runPartialResults.TestEnvironment)));
             Assert.That(ToJson(legacyResults.TestRunner), Is.EqualTo(ToJson(runPartialResults.TestRunner)));
             Assert.That(ToJson(legacyResults.Url), Is.EqualTo(ToJson(runPartialResults.Url)));
-            Assert.That(ToJson(legacyResults.Error), Is.EqualTo(ToJson(runPartialResults.Error)));
             Assert.That(ToJson(legacyResults.TestEngineVersion), Is.EqualTo(ToJson(runPartialResults.TestEngineVersion)));
             Assert.That(ToJson(legacyResults.ToolOptions), Is.EqualTo(ToJson(runPartialResults.ToolOptions)));
         }


### PR DESCRIPTION
## Details
This PR removes the `AxeResult.Error` property that was previously used to indicate a very select few types of errors (exceptions emitted from runLegacy.js or finishRun.js, but only against WebDrivers that didn't normalize those errors as JavaScriptExceptions already) and replaces it with exception-throwing. From a user's perspective, this means that if a scan emits an exception (should be rare anyway), it will propagate as a test failure instead of (probably) ending up silently ignored.

I also added a basic `AxeResult` unit test as part of writing a test for the new functionality. While writing basic unit tests I noticed that the default `ToString` behavior `AxeResult` is currently using is pretty user-unfriendly, but I felt that should be addressed in a separate PR, so I omitted that test/update from this one.

Tests are part of: #22 