### PR TITLE
feat: implement AxeResult.ToString based on JsonConvert

### DIFF
--- a/packages/commons/src/AxeJsonSerializerSettings.cs
+++ b/packages/commons/src/AxeJsonSerializerSettings.cs
@@ -1,0 +1,32 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Deque.AxeCore.Commons
+{
+    /// <summary>
+    /// Provides <see cref="Newtonsoft.Json.JsonSerializerSettings"> values intended for use with the assorted
+    /// Axe* types in this namespace.
+    /// </summary>
+    public static class AxeJsonSerializerSettings
+    {
+        /// <summary>
+        /// The default serialization settings recommended for use with this namespace's Axe* types.
+        /// </summary>
+        public static readonly JsonSerializerSettings Default = WithFormatting(Formatting.None);
+
+        /// <summary>
+        /// Produces serialization settings appropriate for use with this namespace's Axe* types with specific formatting settings.
+        /// </summary>
+        public static JsonSerializerSettings WithFormatting(Formatting formatting) {
+            return new JsonSerializerSettings
+            {
+                Formatting = formatting,
+                NullValueHandling = NullValueHandling.Include,
+                ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new CamelCaseNamingStrategy()
+                },
+            };
+        }
+    }
+}

--- a/packages/commons/src/AxeJsonSerializerSettings.cs
+++ b/packages/commons/src/AxeJsonSerializerSettings.cs
@@ -17,7 +17,8 @@ namespace Deque.AxeCore.Commons
         /// <summary>
         /// Produces serialization settings appropriate for use with this namespace's Axe* types with specific formatting settings.
         /// </summary>
-        public static JsonSerializerSettings WithFormatting(Formatting formatting) {
+        public static JsonSerializerSettings WithFormatting(Formatting formatting)
+        {
             return new JsonSerializerSettings
             {
                 Formatting = formatting,

--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -103,7 +103,7 @@ namespace Deque.AxeCore.Commons
 
         public override string ToString()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonConvert.SerializeObject(this, AxeJsonSerializerSettings.WithFormatting(Formatting.Indented));
         }
     }
 }

--- a/packages/commons/src/AxeResult.cs
+++ b/packages/commons/src/AxeResult.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 
@@ -98,6 +99,11 @@ namespace Deque.AxeCore.Commons
             TestEngineName = testEngineName?.ToObject<string>();
             TestEngineVersion = testEngineVersion?.ToObject<string>();
             ToolOptions = toolOptions?.ToObject<object>();
+        }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
     }
 }

--- a/packages/commons/src/AxeResultItem.cs
+++ b/packages/commons/src/AxeResultItem.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Deque.AxeCore.Commons
 {
     /// <summary>
@@ -39,5 +41,10 @@ namespace Deque.AxeCore.Commons
         /// List of all elements the Rule evaluated to the same result for.
         /// </summary>
         public AxeResultNode[] Nodes { get; set; }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, AxeJsonSerializerSettings.WithFormatting(Formatting.Indented));
+        }
     }
 }

--- a/packages/commons/test/AxeResultItemTest.cs
+++ b/packages/commons/test/AxeResultItemTest.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Deque.AxeCore.Commons.Test
+{
+    [TestFixture]
+    public class AxeResultItemTest
+    {
+        [Test]
+        public void ToStringShouldIncludeEnoughInfoToBeActionable()
+        {
+            var node = new AxeResultNode
+            {
+                All = new AxeResultCheck[] { },
+                Any = new AxeResultCheck[] { },
+                None = new AxeResultCheck[] { },
+                Ancestry = null,
+                Target = new AxeSelector("#selector"),
+                Html = "stub-html",
+                Impact = "stub-impact",
+                XPath = null,
+            };
+
+            var item = new AxeResultItem
+            {
+                Description = "stub desc",
+                Help = "stub help",
+                HelpUrl = "http://example.com/help",
+                Id = "stub-id",
+                Impact = "stub-impact",
+                Tags = new string[] { "tag-1", "tag-2" },
+                Nodes = new AxeResultNode[] { node },
+            };
+
+            var toStringOutput = item.ToString();
+
+            toStringOutput.Should().ContainAll(new string[] {
+                item.Description,
+                item.Help,
+                item.HelpUrl,
+                item.Id,
+                item.Impact,
+                item.Tags[0],
+                item.Tags[1],
+                node.Target.ToString(),
+                node.Html,
+                node.Impact,
+            });
+        }
+    }
+}

--- a/packages/commons/test/AxeResultTest.cs
+++ b/packages/commons/test/AxeResultTest.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Deque.AxeCore.Commons.Test
+{
+    [TestFixture]
+    public class AxeResultTest
+    {
+        readonly string basicAxeResultJson = @"
+{
+  ""testEngine"": {
+    ""name"": ""axe-core"",
+    ""version"": ""4.4.1""
+  },
+  ""testRunner"": {
+    ""name"": ""axe""
+  },
+  ""testEnvironment"": {
+    ""userAgent"": ""Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36"",
+    ""windowWidth"": 800,
+    ""windowHeight"": 600,
+    ""orientationAngle"": 0,
+    ""orientationType"": ""portrait-primary""
+  },
+  ""timestamp"": ""2000-01-02T03:04:05.006Z"",
+  ""url"": ""http://localhost/"",
+  ""toolOptions"": {
+    ""xpath"": true,
+    ""runOnly"": {
+      ""type"": ""rule"",
+      ""values"": [
+        ""document-title""
+      ]
+    },
+    ""reporter"": ""v1""
+  },
+  ""inapplicable"": [],
+  ""passes"": [],
+  ""incomplete"": [],
+  ""violations"": [
+    {
+      ""id"": ""document-title"",
+      ""impact"": ""serious"",
+      ""tags"": [
+        ""cat.text-alternatives"",
+        ""wcag2a"",
+        ""wcag242"",
+        ""ACT""
+      ],
+      ""description"": ""Ensures each HTML document contains a non-empty <title> element"",
+      ""help"": ""Documents must have <title> element to aid in navigation"",
+      ""helpUrl"": ""https://dequeuniversity.com/rules/axe/4.4/document-title?application=axe-puppeteer"",
+      ""nodes"": [
+        {
+          ""any"": [
+            {
+              ""id"": ""doc-has-title"",
+              ""data"": null,
+              ""relatedNodes"": [],
+              ""impact"": ""serious"",
+              ""message"": ""Document does not have a non-empty <title> element""
+            }
+          ],
+          ""all"": [],
+          ""none"": [],
+          ""impact"": ""serious"",
+          ""html"": ""<html><head></head><body>\n</body></html>"",
+          ""target"": [
+            ""html""
+          ],
+          ""xpath"": [
+            ""/html""
+          ],
+          ""failureSummary"": ""Fix any of the following:\n  Document does not have a non-empty <title> element""
+        }
+      ]
+    }
+  ]
+}
+        ";
+
+        [Test]
+        public void ToStringShouldIncludeEnoughInfoToBeActionable()
+        {
+            var result = new AxeResult(JObject.FromObject(JsonConvert.DeserializeObject(basicAxeResultJson)));
+            var toStringOutput = result.ToString();
+
+            toStringOutput.Should().ContainAll(new string[] {
+                "4.4.1",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
+                "2000-01-02T03:04:05.006+00:00",
+                "http://localhost/",
+                "document-title",
+                "wcag242",
+                "serious",
+                "Ensures each HTML document contains a non-empty <title> element",
+                "https://dequeuniversity.com/rules/axe/4.4/document-title?application=axe-puppeteer",
+                "<html><head></head><body>",
+                "</body></html>",
+                "/html",
+                "doc-has-title",
+                "Document does not have a non-empty <title> element",
+            });
+        }
+    }
+}

--- a/packages/commons/test/AxeRunOptionsTest.cs
+++ b/packages/commons/test/AxeRunOptionsTest.cs
@@ -8,11 +8,6 @@ namespace Deque.AxeCore.Commons.Test
     [TestFixture]
     public class AxeRunOptionsTest
     {
-        private readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
-        {
-            Formatting = Formatting.None,
-        };
-
         [Test]
         public void ShouldSerializeRunOnlyOption()
         {
@@ -25,7 +20,7 @@ namespace Deque.AxeCore.Commons.Test
                 }
             };
 
-            var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
+            var serializedObject = JsonConvert.SerializeObject(options, AxeJsonSerializerSettings.Default);
             var expectedObject = "{\"runOnly\":{\"type\":\"tag\",\"values\":[\"tag1\",\"tag2\"]}}";
 
             serializedObject.Should().Be(expectedObject);
@@ -46,7 +41,7 @@ namespace Deque.AxeCore.Commons.Test
             };
             var expectedObject = "{\"rules\":{\"enabledRule\":{\"enabled\":true},\"disabledRule\":{\"enabled\":false},\"rule3WithoutOptionsData\":{}}}";
 
-            var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
+            var serializedObject = JsonConvert.SerializeObject(options, AxeJsonSerializerSettings.Default);
 
             serializedObject.Should().Be(expectedObject);
             JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
@@ -67,7 +62,7 @@ namespace Deque.AxeCore.Commons.Test
             };
             var expectedObject = "{\"selectors\":true,\"ancestry\":true,\"absolutePaths\":true,\"iframes\":true,\"restoreScroll\":true,\"frameWaitTime\":10,\"pingWaitTime\":100}";
 
-            var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
+            var serializedObject = JsonConvert.SerializeObject(options, AxeJsonSerializerSettings.Default);
 
             serializedObject.Should().Be(expectedObject);
             JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
@@ -81,7 +76,7 @@ namespace Deque.AxeCore.Commons.Test
                 ResultTypes = new HashSet<ResultType>() { ResultType.Inapplicable, ResultType.Incomplete, ResultType.Passes, ResultType.Violations }
             };
 
-            var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
+            var serializedObject = JsonConvert.SerializeObject(options, AxeJsonSerializerSettings.Default);
 
             var expectedObject = "{\"resultTypes\":[\"inapplicable\",\"incomplete\",\"passes\",\"violations\"]}";
 

--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -24,23 +24,6 @@ namespace Deque.AxeCore.Selenium
         private string outputFilePath = null;
         private bool useLegacyMode = false;
 
-        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
-        {
-            Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Include
-        };
-
-        private static readonly DefaultContractResolver camelCaseContractResolver = new DefaultContractResolver
-        {
-            NamingStrategy = new CamelCaseNamingStrategy()
-        };
-        private static readonly JsonSerializerSettings JsonSerializerSettingsFinishRun = new JsonSerializerSettings
-        {
-            ContractResolver = camelCaseContractResolver,
-            Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Include
-        };
-
         /// <summary>
         /// Initialize an instance of <see cref="AxeBuilder"/>
         /// </summary>
@@ -230,7 +213,7 @@ namespace Deque.AxeCore.Selenium
         {
             bool runContextHasData = runContext.Include?.Any() == true || runContext.Exclude?.Any() == true;
 
-            string rawContext = runContextHasData ? JsonConvert.SerializeObject(runContext, JsonSerializerSettings) : null;
+            string rawContext = runContextHasData ? JsonConvert.SerializeObject(runContext, AxeJsonSerializerSettings.Default) : null;
 
             return AnalyzeRawContext(rawContext);
         }
@@ -320,8 +303,8 @@ namespace Deque.AxeCore.Selenium
             {
                 try
                 {
-                    object frameContext = JsonConvert.SerializeObject(fContext.Context, JsonSerializerSettings);
-                    object frameSelector = JsonConvert.SerializeObject(fContext.Selector, JsonSerializerSettings);
+                    object frameContext = JsonConvert.SerializeObject(fContext.Context, AxeJsonSerializerSettings.Default);
+                    object frameSelector = JsonConvert.SerializeObject(fContext.Selector, AxeJsonSerializerSettings.Default);
                     var frame = _webDriver.ExecuteScript(EmbeddedResourceProvider.ReadEmbeddedFile("shadowSelect.js"), frameSelector);
                     _webDriver.SwitchTo().Frame(frame as IWebElement);
 
@@ -364,7 +347,7 @@ namespace Deque.AxeCore.Selenium
 
             ConfigureAxe();
 
-            var serializedPartials = JsonConvert.SerializeObject(partialResults, JsonSerializerSettingsFinishRun);
+            var serializedPartials = JsonConvert.SerializeObject(partialResults, AxeJsonSerializerSettings.Default);
             // grab result ...
             var result = _webDriver.ExecuteAsyncScript(EmbeddedResourceProvider.ReadEmbeddedFile("finishRun.js"), serializedPartials, options);
 
@@ -423,7 +406,7 @@ namespace Deque.AxeCore.Selenium
 
         private string SerializedRunOptions()
         {
-            return JsonConvert.SerializeObject(runOptions, JsonSerializerSettings);
+            return JsonConvert.SerializeObject(runOptions, AxeJsonSerializerSettings.Default);
         }
 
         private static void ValidateParameters(string[] parameterValue, string parameterName)

--- a/packages/selenium/test/AxeBuilderLegacyTest.cs
+++ b/packages/selenium/test/AxeBuilderLegacyTest.cs
@@ -26,11 +26,6 @@ namespace Deque.AxeCore.Selenium.Test
         private static Mock<IWebDriver> webDriverMock = new Mock<IWebDriver>();
         private static Mock<IJavaScriptExecutor> jsExecutorMock = webDriverMock.As<IJavaScriptExecutor>();
         private static Mock<ITargetLocator> targetLocatorMock = new Mock<ITargetLocator>();
-        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
-        {
-            Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Ignore
-        };
 
         private static readonly AxeBuilderOptions stubAxeBuilderOptions = new AxeBuilderOptions
         {
@@ -333,7 +328,7 @@ namespace Deque.AxeCore.Selenium.Test
 
         private string SerializeObject<T>(T obj)
         {
-            return JsonConvert.SerializeObject(obj, JsonSerializerSettings);
+            return JsonConvert.SerializeObject(obj, AxeJsonSerializerSettings.Default);
         }
 
     }

--- a/packages/selenium/test/AxeBuilderTest.cs
+++ b/packages/selenium/test/AxeBuilderTest.cs
@@ -27,11 +27,6 @@ namespace Deque.AxeCore.Selenium.Test
         private static Mock<IJavaScriptExecutor> jsExecutorMock = webDriverMock.As<IJavaScriptExecutor>();
         private static Mock<ITargetLocator> targetLocatorMock = new Mock<ITargetLocator>();
         private static Mock<INavigation> navigationMock = new Mock<INavigation>();
-        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
-        {
-            Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Ignore
-        };
 
         private static readonly AxeBuilderOptions stubAxeBuilderOptions = new AxeBuilderOptions
         {
@@ -352,7 +347,7 @@ namespace Deque.AxeCore.Selenium.Test
 
         private string SerializeObject<T>(T obj)
         {
-            return JsonConvert.SerializeObject(obj, JsonSerializerSettings);
+            return JsonConvert.SerializeObject(obj, AxeJsonSerializerSettings.Default);
         }
 
     }

--- a/packages/selenium/test/RunPartial/FinishRunTests.cs
+++ b/packages/selenium/test/RunPartial/FinishRunTests.cs
@@ -66,15 +66,9 @@ namespace Deque.AxeCore.Selenium.Test.RunPartial
             Assert.That(ToJson(legacyResults.ToolOptions), Is.EqualTo(ToJson(runPartialResults.ToolOptions)));
         }
 
-        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
-        {
-            Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Include
-        };
-
         private static string ToJson(object obj)
         {
-            return JsonConvert.SerializeObject(obj, JsonSerializerSettings);
+            return JsonConvert.SerializeObject(obj, AxeJsonSerializerSettings.Default);
         }
 
         private static void AssertAxeItemsEqual(AxeResultItem a, AxeResultItem b, bool compareNodes = false)


### PR DESCRIPTION
## Details
This PR adds in a basic ToString implementation for `AxeResult` and `AxeResultItem` that just uses `JsonConvert.SerializeObject`.

The motivation for this is that these types are likely to be used in users' test assertions; when an assertion related to them fails, we want the test output to be actionable.

I wanted to reuse the same `JsonSerializerSettings` as everywhere else in the Selenium package, so I extracted it out of `AxeBuilder` (and several tests that repeated bits of it) into a `AxeJsonSerializerSettings` static class in the commons package. I think this is a better home for the serializer settings anyway, since they're tightly coupled to the implementation of the types.

The test addition will have a merge conflict to resolve with #74, which adds overlapping unit tests that share the same sample input JSON.

Example output of `AxeResult.ToString()` using the pinned sample input from the new unit test:

```json
{
  "violations": [
    {
      "id": "document-title",
      "description": "Ensures each HTML document contains a non-empty <title> element",
      "help": "Documents must have <title> element to aid in navigation",
      "helpUrl": "https://dequeuniversity.com/rules/axe/4.4/document-title?application=axe-puppeteer",
      "impact": "serious",
      "tags": [
        "cat.text-alternatives",
        "wcag2a",
        "wcag242",
        "ACT"
      ],
      "nodes": [
        {
          "target": "html",
          "xPath": "/html",
          "ancestry": null,
          "html": "<html><head></head><body>\n</body></html>",
          "impact": "serious",
          "any": [
            {
              "data": null,
              "id": "doc-has-title",
              "impact": "serious",
              "message": "Document does not have a non-empty <title> element",
              "relatedNodes": []
            }
          ],
          "all": [],
          "none": []
        }
      ]
    }
  ],
  "passes": [],
  "inapplicable": [],
  "incomplete": [],
  "timestamp": "2000-01-02T03:04:05.006+00:00",
  "testEnvironment": {
    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
    "windowWidth": 800,
    "windowHeight": 600,
    "orientationType": "portrait-primary",
    "orientationAngle": 0.0
  },
  "testRunner": {
    "name": "axe"
  },
  "url": "http://localhost/",
  "error": null,
  "testEngineName": "axe-core",
  "testEngineVersion": "4.4.1",
  "toolOptions": {
    "xpath": true,
    "runOnly": {
      "type": "rule",
      "values": [
        "document-title"
      ]
    },
    "reporter": "v1"
  }
}
```
