### PR TITLE
feat(selenium): Add Post-Analyze Callback to the Selenium Axe Builder

### DIFF
--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -23,6 +23,7 @@ namespace Deque.AxeCore.Selenium
         private AxeRunOptions runOptions = new AxeRunOptions();
         private string outputFilePath = null;
         private bool useLegacyMode = false;
+        private Action<AxeResult, AxeRunOptions, IWebDriver> _postAnalyzeCallback;
 
         /// <summary>
         /// Initialize an instance of <see cref="AxeBuilder"/>
@@ -107,6 +108,16 @@ namespace Deque.AxeCore.Selenium
                 Type = "rule",
                 Values = rules.ToList()
             };
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a callback which will be invoked after Analyze is called.
+        /// </summary>
+        public AxeBuilder WithPostAnalyzeCallback(Action<AxeResult, AxeRunOptions, IWebDriver> postAnalyzeHook)
+        {
+            _postAnalyzeCallback = postAnalyzeHook;
 
             return this;
         }
@@ -248,8 +259,14 @@ namespace Deque.AxeCore.Selenium
                 }
             }
 
-            return new AxeResult(resultObject);
+            AxeResult axeResult = new AxeResult(resultObject);
 
+            if (_postAnalyzeCallback != null)
+            {
+                _postAnalyzeCallback(axeResult, runOptions, _webDriver);
+            }
+
+            return axeResult;
         }
 
         private JObject AnalyzeAxeRunPartial(object rawContextArg)

--- a/packages/selenium/test/AxeBuilderTest.cs
+++ b/packages/selenium/test/AxeBuilderTest.cs
@@ -257,7 +257,7 @@ namespace Deque.AxeCore.Selenium.Test
             SetupVerifiableScanCall(null, "{}");
 
             var builder = new AxeBuilder(webDriverMock.Object, stubAxeBuilderOptions)
-                .WithPostAnalyzeHook(postAnalyzeCallbackMock.Object.PostAnalyzeCallback);
+                .WithPostAnalyzeCallback(postAnalyzeCallbackMock.Object.PostAnalyzeCallback);
 
             var result = builder.Analyze();
 


### PR DESCRIPTION
## Details
<!-- Provide a sentence or two describing what the PR changes -->

On the project which [adds a HTML Reporter](https://github.com/microsoft/html-reporter-for-axe-core-dotnet) I need to be able to extend the functionality of the selenium AxeBuilder class so that:
1. I can add a method to the builder to add and configure a HTML report.
2. The report gets created when Analyze is invoked.

Something along the lines of:

```csharp
AxeBuilder builder = new AxeBuilder()
            .WithHTMLReport()
           .Analyze(); // Report is now written to file
```

The suggested approach here is to introduce a generic callback which can be added to the builder and which is invoked directly after Analyze is called:

```csharp
AxeBuilder builder = new AxeBuilder()
           .WithPostAnalyzeCallback((result, options, driver) => {});
```


Let me know if a different extensibility method is preferred.
