### PR TITLE
ci: update `prepare_release.sh` to take optional release level

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -7,7 +7,7 @@ releaseLevel="$1"
 
 oldVersion="$(node -pe 'require("./package.json").version')"
 
-# If no release level is specified, let standard-version handle versioning
+# If no release level is specified, let commit-and-tag-version handle versioning
 if [ -z "$releaseLevel" ] 
 then
   npx commit-and-tag-version --skip.commit=true --skip.changelog=true --skip.tag=true

--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -6,7 +6,15 @@ set -e
 releaseLevel="$1"
 
 oldVersion="$(node -pe 'require("./package.json").version')"
-npx commit-and-tag-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
+
+# If no release level is specified, let standard-version handle versioning
+if [ -z "$releaseLevel" ] 
+then
+  npx commit-and-tag-version --skip.commit=true --skip.changelog=true --skip.tag=true
+else
+  npx commit-and-tag-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
+fi
+
 newVersion="$(node -pe 'require("./package.json").version')"
 
 sed -i -e "s/<VersionPrefix>$oldVersion<\/VersionPrefix>/<VersionPrefix>$newVersion<\/VersionPrefix>/" ./packages/*/src/*.csproj


### PR DESCRIPTION
This PR allows the unnamed argument to be optional, if it's not specified it will default to lerna handling version, otherwise it will release as the specified release level.

<details>
<summary>Without specifying a release level</summary>
<img width="942" alt="image" src="https://github.com/dequelabs/axe-core-nuget/assets/41127686/01acaba5-9b4d-45e4-a1cb-abb880feb962">

</details>


<details>
<summary>With release level</summary>
<img width="993" alt="image" src="https://github.com/dequelabs/axe-core-nuget/assets/41127686/917cec85-3d9a-4b0c-854d-77053a497993">

</details>


Closes: https://github.com/dequelabs/axe-core-nuget/issues/120


