### PR TITLE
chore: add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dequelabs/axe-api-team


### PR DESCRIPTION
Noticed raising a PR we do not have a code owners so we are not notified of incoming PR's 

No QA required 