### PR TITLE
ci: add release branch check to publish-canary.yml

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - release
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Closes: https://github.com/dequelabs/axe-core-nuget/issues/127