### PR TITLE
chore: add timeouts to GitHub Actions jobs

### DIFF
--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -5,6 +5,7 @@ jobs:
   create_patch_release:
     name: Create release
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - name: Determine if we skip cancel checks
         id: skip-checks

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,7 @@ jobs:
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   create-release-candidate:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: dequelabs/axe-api-team-public/.github/actions/create-release-candidate-v1@main
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,6 +12,7 @@ jobs:
   create_release:
     name: Create release
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -22,6 +22,7 @@ jobs:
     if: github.repository_owner == 'dequelabs' # don't attempt to publish from forks
     needs: ["publish-nuget"]
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       contents: write # this permission controls release creation
     steps:     

--- a/.github/workflows/semantic-pr-footer.yml
+++ b/.github/workflows/semantic-pr-footer.yml
@@ -11,5 +11,6 @@ on:
 jobs:
   semantic-pr-footer:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: dequelabs/axe-api-team-public/.github/actions/semantic-pr-footer-v1@main

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -11,5 +11,6 @@ on:
 jobs:
   semantic-pr-title:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: dequelabs/semantic-pr-title@v1

--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   create_sync_pull_request:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       pull-requests: write
     if: github.event.pull_request.merged == 'true'

--- a/.github/workflows/update-axe-core.yml
+++ b/.github/workflows/update-axe-core.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Reviewer note: some of this repo's GHA setup is based on reusable workflows, which support setting job timeouts only on the reused inner workflow (eg, `build-and-test.yml`, `publish-nuget-packages.yml`) and not the containing workflows; that's why it looks like some jobs are omitted (eg, `pull-request.yml`)

Closes: #139