### PR TITLE
docs(playwright): fix broken readme examples

### DIFF
--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -163,7 +163,7 @@ runContext = new AxeRunContext()
 AxeResult axeResults = await page.RunAxe(runContext);
 ```
 
-All `RunAxe` methods also support an `AxeRunOptions`` parameter.
+All `RunAxe` methods also support an `AxeRunOptions` parameter.
 This corresponds to the [axe.run Options parameter](https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter).
 
 ```cs

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -146,7 +146,7 @@ runContext = new AxeRunContext()
 
 runContext = new AxeRunContext()
 {
-    // Run on every button except #excluded-id.
+    // Run on every button except #my-id.
     Include = new List<AxeSelector>() { new AxeSelector("button") },
     Exclude = new List<AxeSelector>() { new AxeSelector("#my-id") }
 };

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -119,7 +119,7 @@ foreach(var inapplicable in axeResults.Inapplicable)
 
 `RunAxe` is supported on both Playwright `Page`s and Playwright `Locator`s. `Locator`s are the easiest way to run axe against only part of a page:
 
-``` cs
+```cs
 ILocator locator = page.Locator("text=Sign In");
 
 AxeResult axeResults = await locator.RunAxe();
@@ -127,7 +127,7 @@ AxeResult axeResults = await locator.RunAxe();
 
 Alternately, when used on a `Page`, `RunAxe` supports an `AxeRunContext` parameter which supports more complex rules for deciding which parts of a page to scan (or exclude from a scan). This corresponds to the [axe.run Context parameter](https://www.deque.com/axe/core-documentation/api-documentation/#context-parameter):
 
-``` cs
+```cs
 AxeRunContext runContext = new AxeRunContext()
 {
     // Only run on this #my-id.
@@ -232,24 +232,24 @@ In a move to standardize, we migrated this package away from Playwright specific
 1. `AxeRelatedNode` has been replaced with `AxeResultRelatedNode`. With this type, the Targets property is changed from a `IList<string>` to a `List<AxeResultTarget>`; users should expect to modify usages of the Targets property to include a `.ToString()` method call.
 1. `AxeRunSerialContext` has been replaced by `AxeRunContext` and `AxeSelector` types. Here are some examples of how to use the new types:
  
-        ```cs
-        // Finding a single element using the Playwright Locator API.
-        ILocator locator = page.GetByRole("menu").RunAxe();
-        
-        // Iincluding/excluding elements in the main frame.
-        new AxeRunContext()
-            {
-                Include = new List<AxeSelector> { new AxeSelector("#foo") },
-                Exclude = new List<AxeSelector> {},
-            };
+```cs
+// Finding a single element using the Playwright Locator API.
+ILocator locator = page.GetByRole("menu").RunAxe();
 
-        // Including/excluding an element in a child frame.
-        new AxeRunContext()
-            {
-                Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
-                Exclude = new List<AxeSelector> {},
-            };
-        ```
+// Iincluding/excluding elements in the main frame.
+new AxeRunContext()
+    {
+        Include = new List<AxeSelector> { new AxeSelector("#foo") },
+        Exclude = new List<AxeSelector> {},
+    };
+
+// Including/excluding an element in a child frame.
+new AxeRunContext()
+    {
+        Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
+        Exclude = new List<AxeSelector> {},
+    };
+```
 
 ### Type Modifications
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -240,7 +240,7 @@ In a move to standardize, we migrated this package away from Playwright specific
 // Finding a single element using the Playwright Locator API.
 ILocator locator = page.GetByRole("menu").RunAxe();
 
-// Iincluding/excluding elements in the main frame.
+// Including/excluding elements in the main frame.
 new AxeRunContext()
 {
     Include = new List<AxeSelector> { new AxeSelector("#foo") },

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -136,8 +136,12 @@ AxeRunContext runContext = new AxeRunContext()
 
 runContext = new AxeRunContext()
 {
-    // Run on everything except #my-id.
-    Exclude = new List<AxeSelector>() { new AxeSelector("#my-id") }
+    // Run on everything except #my-id and #second-id.
+    Exclude = new List<AxeSelector>()
+    {
+        new AxeSelector("#my-id"),
+        new AxeSelector("#second-id"),
+    }
 };
 
 runContext = new AxeRunContext()
@@ -238,17 +242,17 @@ ILocator locator = page.GetByRole("menu").RunAxe();
 
 // Iincluding/excluding elements in the main frame.
 new AxeRunContext()
-    {
-        Include = new List<AxeSelector> { new AxeSelector("#foo") },
-        Exclude = new List<AxeSelector> {},
-    };
+{
+    Include = new List<AxeSelector> { new AxeSelector("#foo") },
+    Exclude = new List<AxeSelector> {},
+};
 
 // Including/excluding an element in a child frame.
 new AxeRunContext()
-    {
-        Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
-        Exclude = new List<AxeSelector> {},
-    };
+{
+    Include = new List<AxeSelector> { new AxeSelector("#element-in-child-frame", new List<string> { "#iframe-in-main-frame" })},
+    Exclude = new List<AxeSelector> {},
+};
 ```
 
 ### Type Modifications

--- a/packages/playwright/src/LocatorExtensions.cs
+++ b/packages/playwright/src/LocatorExtensions.cs
@@ -19,7 +19,7 @@ namespace Deque.AxeCore.Playwright
         /// </summary>
         /// <param name="locator">The Playwright Locator</param>
         /// <param name="options">Options for running Axe.</param>
-        /// <returns>The AxeResults</returns>
+        /// <returns>The AxeResult</returns>
         public static async Task<AxeResult> RunAxe(this ILocator locator, AxeRunOptions? options = null)
         {
             IAxeScriptProvider axeScriptProvider = new BundledAxeScriptProvider();
@@ -35,7 +35,7 @@ namespace Deque.AxeCore.Playwright
         /// </summary>
         /// <param name="locator">The Playwright Locator</param>
         /// <param name="options">Options for running Axe.</param>
-        /// <returns>The AxeResults</returns>
+        /// <returns>The AxeResult</returns>
         [Obsolete("Legacy Mode is being removed in the future. Use with caution!")]
         public static async Task<AxeResult> RunAxeLegacy(this ILocator locator, AxeRunOptions? options = null)
         {

--- a/packages/playwright/test/IntegrationTests.cs
+++ b/packages/playwright/test/IntegrationTests.cs
@@ -369,8 +369,12 @@ namespace Deque.AxeCore.Playwright.Test
 
             runContext = new AxeRunContext()
             {
-                // Run on everything except #my-id.
-                Exclude = new List<AxeSelector>() { new AxeSelector("#my-id") }
+                // Run on everything except #my-id and #second-id.
+                Exclude = new List<AxeSelector>()
+                {
+                    new AxeSelector("#my-id"),
+                    new AxeSelector("#second-id"),
+                }
             };
 
             runContext = new AxeRunContext()

--- a/packages/playwright/test/IntegrationTests.cs
+++ b/packages/playwright/test/IntegrationTests.cs
@@ -281,6 +281,114 @@ namespace Deque.AxeCore.Playwright.Test
                     includedInTargets == targets.Contains(node.Target.ToString()))));
         }
 
+        [Test]
+        public async Task RunAxe_ReadmeExample() {
+            AxeResult axeResults = await Page.RunAxe();
+
+            Console.WriteLine($"Axe ran against {axeResults.Url} on {axeResults.Timestamp}.");
+
+            Console.WriteLine($"Rules that failed:");
+            foreach(var violation in axeResults.Violations)
+            {
+                Console.WriteLine($"Rule Id: {violation.Id} Impact: {violation.Impact} HelpUrl: {violation.HelpUrl}.");
+
+                foreach(var node in violation.Nodes)
+                {
+                    Console.WriteLine($"\tViolation found at: {node.Target}");
+                    Console.WriteLine($"\t...with HTML: {node.Html}");
+                }
+            }
+
+            Console.WriteLine($"Rules that passed successfully:");
+            foreach(var pass in axeResults.Passes)
+            {
+                Console.WriteLine($"Rule Id: {pass.Id} Impact: {pass.Impact} HelpUrl: {pass.HelpUrl}.");
+            }
+
+            Console.WriteLine($"Rules that did not fully run:");
+            foreach(var incomplete in axeResults.Incomplete)
+            {
+                Console.WriteLine($"Rule Id: {incomplete.Id}.");
+            }
+
+            Console.WriteLine($"Rules that were not applicable:");
+            foreach(var inapplicable in axeResults.Inapplicable)
+            {
+                Console.WriteLine($"Rule Id: {inapplicable.Id}.");
+            }
+        }
+
+        [Test]
+        public async Task AxeRunOptions_ReadmeExample() {
+            AxeRunOptions options = new AxeRunOptions()
+            {
+                // Run only tags that are wcag2aa.
+                RunOnly = new RunOnlyOptions { Type = "tag", Values = new List<string> { "wcag2aa" } },
+
+                // Specify rules.
+                Rules = new Dictionary<string, RuleOptions>()
+                {
+                    // Don't run color-contrast.
+                    { "color-contrast", new RuleOptions() { Enabled = false } }
+                },
+
+                // Limit result types to Violations.
+                ResultTypes = new HashSet<ResultType>()
+                {
+                    ResultType.Violations
+                },
+
+                // Don't return css selectors in results.
+                Selectors = false,
+
+                // Return CSS selector for elements, with all the element's ancestors.
+                Ancestry = true,
+
+                // Don't return xpath selectors for elements.
+                XPath = false,
+
+                // Don't run axe on iframes inside the document.
+                Iframes = false
+            };
+
+            AxeResult axeResults = await Page.RunAxe(options);
+        }
+
+        [Test]
+        public async Task AxeRunContext_ReadmeExample() {
+            await NavigateToPage("selector.html");
+
+            AxeRunContext runContext = new AxeRunContext()
+            {
+                // Only run on this #my-id.
+                Include = new List<AxeSelector>() { new AxeSelector("#my-id") }
+            };
+
+            runContext = new AxeRunContext()
+            {
+                // Run on everything except #my-id.
+                Exclude = new List<AxeSelector>() { new AxeSelector("#my-id") }
+            };
+
+            runContext = new AxeRunContext()
+            {
+                // Run on every button except #excluded-id.
+                Include = new List<AxeSelector>() { new AxeSelector("button") },
+                Exclude = new List<AxeSelector>() { new AxeSelector("#my-id") }
+            };
+
+            runContext = new AxeRunContext()
+            {
+                // Run on everything, except for #my-id within the iframe #my-frame.
+                Exclude = new List<AxeSelector>()
+                {
+                    new AxeSelector("#my-id", new List<string>() { "#my-frame" })
+                }
+            };
+
+            AxeResult axeResults = await Page.RunAxe(runContext);
+        }
+
         static object[] RunAxe_WithContext_Cases = {
             new object[]
             {

--- a/packages/playwright/test/IntegrationTests.cs
+++ b/packages/playwright/test/IntegrationTests.cs
@@ -282,17 +282,18 @@ namespace Deque.AxeCore.Playwright.Test
         }
 
         [Test]
-        public async Task RunAxe_ReadmeExample() {
+        public async Task RunAxe_ReadmeExample()
+        {
             AxeResult axeResults = await Page.RunAxe();
 
             Console.WriteLine($"Axe ran against {axeResults.Url} on {axeResults.Timestamp}.");
 
             Console.WriteLine($"Rules that failed:");
-            foreach(var violation in axeResults.Violations)
+            foreach (var violation in axeResults.Violations)
             {
                 Console.WriteLine($"Rule Id: {violation.Id} Impact: {violation.Impact} HelpUrl: {violation.HelpUrl}.");
 
-                foreach(var node in violation.Nodes)
+                foreach (var node in violation.Nodes)
                 {
                     Console.WriteLine($"\tViolation found at: {node.Target}");
                     Console.WriteLine($"\t...with HTML: {node.Html}");
@@ -300,26 +301,27 @@ namespace Deque.AxeCore.Playwright.Test
             }
 
             Console.WriteLine($"Rules that passed successfully:");
-            foreach(var pass in axeResults.Passes)
+            foreach (var pass in axeResults.Passes)
             {
                 Console.WriteLine($"Rule Id: {pass.Id} Impact: {pass.Impact} HelpUrl: {pass.HelpUrl}.");
             }
 
             Console.WriteLine($"Rules that did not fully run:");
-            foreach(var incomplete in axeResults.Incomplete)
+            foreach (var incomplete in axeResults.Incomplete)
             {
                 Console.WriteLine($"Rule Id: {incomplete.Id}.");
             }
 
             Console.WriteLine($"Rules that were not applicable:");
-            foreach(var inapplicable in axeResults.Inapplicable)
+            foreach (var inapplicable in axeResults.Inapplicable)
             {
                 Console.WriteLine($"Rule Id: {inapplicable.Id}.");
             }
         }
 
         [Test]
-        public async Task AxeRunOptions_ReadmeExample() {
+        public async Task AxeRunOptions_ReadmeExample()
+        {
             AxeRunOptions options = new AxeRunOptions()
             {
                 // Run only tags that are wcag2aa.
@@ -355,7 +357,8 @@ namespace Deque.AxeCore.Playwright.Test
         }
 
         [Test]
-        public async Task AxeRunContext_ReadmeExample() {
+        public async Task AxeRunContext_ReadmeExample()
+        {
             await NavigateToPage("selector.html");
 
             AxeRunContext runContext = new AxeRunContext()

--- a/packages/playwright/test/IntegrationTests.cs
+++ b/packages/playwright/test/IntegrationTests.cs
@@ -379,7 +379,7 @@ namespace Deque.AxeCore.Playwright.Test
 
             runContext = new AxeRunContext()
             {
-                // Run on every button except #excluded-id.
+                // Run on every button except #my-id.
                 Include = new List<AxeSelector>() { new AxeSelector("button") },
                 Exclude = new List<AxeSelector>() { new AxeSelector("#my-id") }
             };


### PR DESCRIPTION
## Details
A user in our community slack reported having some trouble with our readme example. I went through all the README examples and updated some cases that weren't updated properly when migrating the original library code. I added integration tests for the more complex samples to verify that they run as-written.

Closes: #143 