### PR TITLE
ci: update pr-template path

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -16,4 +16,5 @@ jobs:
           pr-title: 'chore: merge master into develop'
           pr-team-reviewers: axe-api-team
           pr-labels: chore
+          pr-template: '.github/PULL_REQUEST_TEMPLATE.md'
           pr-body: 'Remember to _merge_ (rather than squash) this PR!'


### PR DESCRIPTION
It looks like the default path is [`.github/pull_request_template.md`](https://github.com/dequelabs/action-sync-branches/blob/develop/action.yml#L21) in this repo it is `.github/PULL_REQUEST_TEMPLATE.MD`

no qa required