### PR TITLE
chore: add note about semver to READMEs

### DIFF
--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -7,6 +7,8 @@ Automated web accessibility testing with .NET, C#, and Playwright. Wraps the [ax
 
 Compatible with .NET Standard 2.1.
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Getting Started
 
 Install via NuGet:

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -7,6 +7,8 @@ Automated web accessibility testing with .NET, C#, and Selenium. Wraps the [axe-
 
 Compatible with .NET Standard 2.0+, .NET Framework 4.7.1+, and .NET Core 2.0+.
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Getting Started
 
 Install via NuGet:


### PR DESCRIPTION
As per our policy to add a message about how we don't strictly follow semver to our documentation.

No QA required.