### PR TITLE
ci(dependabot): use cooldown delay recent updates

### DIFF
--- a/packages/selenium/.github/dependabot.yml
+++ b/packages/selenium/.github/dependabot.yml
@@ -32,4 +32,4 @@ updates:
   - dependencies
   versioning-strategy: increase
   cooldown:
-      default-days: 7
+    default-days: 7

--- a/packages/selenium/.github/dependabot.yml
+++ b/packages/selenium/.github/dependabot.yml
@@ -6,9 +6,10 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+  cooldown:
+      default-days: 7
   labels:
   - dependencies
-  commit-message:
   ignore:
     # FluentAssertions v6 dropped support for .NET Framework 4.5, but we want
     # to maintain support for it at least until Microsoft drops official support,
@@ -20,7 +21,7 @@ updates:
   - dependency-name: FluentAssertions
     versions:
     - ">=8.0.0"
-  
+
 - package-ecosystem: npm
   directory: "/Selenium.Axe/Selenium.Axe"
   schedule:
@@ -30,4 +31,5 @@ updates:
   labels:
   - dependencies
   versioning-strategy: increase
-  commit-message:
+  cooldown:
+      default-days: 7

--- a/packages/selenium/.github/dependabot.yml
+++ b/packages/selenium/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "11:00"
   open-pull-requests-limit: 10
   cooldown:
-      default-days: 7
+    default-days: 7
   labels:
   - dependencies
   ignore:


### PR DESCRIPTION
This applies the new [cooldown option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) for dependabot. It will hold updates until after they have been out for at least a week. This will allow a reasonable time for packages to exist and if any issues exist in the supply chain, get caught before the updates come through.

This one also drops the `commit-message` property. The prefix was [removed back in 2020](https://github.com/dequelabs/axe-core-nuget/commit/88ac393f8af57a3c32d3e6fdcbb36b54ff38e2e7) and either the syntax was invalid then and no one caught it or it became invalid at some point after. Since we make no modifications, we don't need the property.

No QA Needed
Refs: https://github.com/dequelabs/axe-api-team/issues/598
