### PR TITLE
ci: use pat instead of github token

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: dequelabs/axe-api-team-public/.github/actions/create-release-candidate-v1@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           base: "master"
           head: "develop"
           release-script-path: "./.github/scripts/prepare_release.sh"


### PR DESCRIPTION
## Summary
- Switch the `create-release-candidate` workflow's `token:` input from `secrets.GITHUB_TOKEN` to `secrets.PAT`.
- `GITHUB_TOKEN`-authored events are blocked from triggering subsequent workflow runs (GitHub's recursion guard); a PAT bypasses that so the release pipeline runs end-to-end.


No QA Required