### PR TITLE
ci: use GH_PROJECT_TOKEN for create-release-candidate

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: dequelabs/axe-api-team-public/.github/actions/create-release-candidate-v1@main
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GH_PROJECT_TOKEN }}
           base: "master"
           head: "develop"
           release-script-path: "./.github/scripts/prepare_release.sh"


### PR DESCRIPTION
## Summary
- #241 changed `create-release-candidate.yml` to use `secrets.PAT`, but no `PAT` secret exists on this repo, so the input evaluated to empty and the action failed with `Input required and not supplied: github-token` (see [run 25132202405](https://github.com/dequelabs/axe-core-nuget/actions/runs/25132202405/job/73661138098)).
- Switch `token` to the existing `GH_PROJECT_TOKEN`, which is already used by `env.GH_TOKEN` in this same step. This preserves the intent of #241 (use a PAT so the resulting PR can trigger downstream workflows) without needing to add a new secret.

## Test plan
- [ ] Re-run the **Create release candidate** workflow from `develop` and confirm the action succeeds and opens the RC PR.

No QA required