### PR TITLE
chore(selenium): add LegacyWebDriver and NewWebDriver build variants

### DIFF
--- a/Deque.AxeCore.sln
+++ b/Deque.AxeCore.sln
@@ -20,6 +20,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Playwright", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Playwright.Test", "packages\playwright\test\Deque.AxeCore.Playwright.Test.csproj", "{8C4FBD5E-384C-4767-9F40-6FECE4A97D1B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Selenium.LegacyWebDriver", "packages\selenium\legacy-webdriver\Deque.AxeCore.Selenium.LegacyWebDriver.csproj", "{FFD9848A-EA97-482A-97C5-595BB9CF6207}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deque.AxeCore.Selenium.NewWebDriver", "packages\selenium\new-webdriver\Deque.AxeCore.Selenium.NewWebDriver.csproj", "{103861FC-3F41-4617-B746-41432BC3B2F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +57,14 @@ Global
 		{8C4FBD5E-384C-4767-9F40-6FECE4A97D1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C4FBD5E-384C-4767-9F40-6FECE4A97D1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C4FBD5E-384C-4767-9F40-6FECE4A97D1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFD9848A-EA97-482A-97C5-595BB9CF6207}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFD9848A-EA97-482A-97C5-595BB9CF6207}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFD9848A-EA97-482A-97C5-595BB9CF6207}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFD9848A-EA97-482A-97C5-595BB9CF6207}.Release|Any CPU.Build.0 = Release|Any CPU
+		{103861FC-3F41-4617-B746-41432BC3B2F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{103861FC-3F41-4617-B746-41432BC3B2F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103861FC-3F41-4617-B746-41432BC3B2F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{103861FC-3F41-4617-B746-41432BC3B2F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{05A828D4-ED6F-4C8E-8D7C-62B84E3C359E} = {503C1F96-0BAB-457A-AC0F-F8E596F3ADD6}
@@ -61,5 +73,7 @@ Global
 		{7D5DB0A8-263E-40D4-90C8-B86BA672C783} = {7273D75C-DB83-4C12-B48D-7C575A8DEBC7}
 		{5AB8F02B-C656-41A0-A05A-A254EB5D12B0} = {0106102C-9CEF-4DAF-919F-52D3F4D6FF16}
 		{8C4FBD5E-384C-4767-9F40-6FECE4A97D1B} = {0106102C-9CEF-4DAF-919F-52D3F4D6FF16}
+		{FFD9848A-EA97-482A-97C5-595BB9CF6207} = {7273D75C-DB83-4C12-B48D-7C575A8DEBC7}
+		{103861FC-3F41-4617-B746-41432BC3B2F1} = {7273D75C-DB83-4C12-B48D-7C575A8DEBC7}
 	EndGlobalSection
 EndGlobal

--- a/packages/selenium/legacy-webdriver/Deque.AxeCore.Selenium.LegacyWebDriver.csproj
+++ b/packages/selenium/legacy-webdriver/Deque.AxeCore.Selenium.LegacyWebDriver.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\src\*.cs">
-      <Link>%(Filename)%(Extension)</Link>
+    <Compile Include="..\src\**\*.cs" Exclude="..\src\bin\**\*;..\src\obj\**\*">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 

--- a/packages/selenium/legacy-webdriver/Deque.AxeCore.Selenium.LegacyWebDriver.csproj
+++ b/packages/selenium/legacy-webdriver/Deque.AxeCore.Selenium.LegacyWebDriver.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Deque.AxeCore.Selenium</AssemblyName>
+    <RootNamespace>Deque.AxeCore.Selenium</RootNamespace>
+
+    <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\src\*.cs">
+      <Link>%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\src\Resources\*.js">
+      <Link>Resources\%(Filename)%(Extension)</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\commons\src\Deque.AxeCore.Commons.csproj" />
+  </ItemGroup>
+</Project>

--- a/packages/selenium/new-webdriver/Deque.AxeCore.Selenium.NewWebDriver.csproj
+++ b/packages/selenium/new-webdriver/Deque.AxeCore.Selenium.NewWebDriver.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\src\*.cs">
-      <Link>%(Filename)%(Extension)</Link>
+    <Compile Include="..\src\**\*.cs" Exclude="..\src\bin\**\*;..\src\obj\**\*">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 

--- a/packages/selenium/new-webdriver/Deque.AxeCore.Selenium.NewWebDriver.csproj
+++ b/packages/selenium/new-webdriver/Deque.AxeCore.Selenium.NewWebDriver.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Deque.AxeCore.Selenium</AssemblyName>
+    <RootNamespace>Deque.AxeCore.Selenium</RootNamespace>
+
+    <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\src\*.cs">
+      <Link>%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\src\Resources\*.js">
+      <Link>Resources\%(Filename)%(Extension)</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\commons\src\Deque.AxeCore.Commons.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

First PR (of ~4) toward supporting both pre-4.44 and post-4.44 `Selenium.WebDriver` consumers from a single `Deque.AxeCore.Selenium` NuGet package. Tracked in #252; design in [the dual-Selenium support plan gist](https://gist.github.com/scottmries/359d7a8e5e92b4f536e7240e40c6b3a8); fixes #248 once the full series lands.

Selenium 4.44.0 renamed its compiled assembly from `WebDriver.dll` to `Selenium.WebDriver.dll` (and strong-signed it). Because our compiled DLL bakes an assembly reference to one or the other, a single binary can't serve both consumer worlds — we need to ship two and dispatch between them at consume time. This PR sets up the two build variants. Subsequent PRs add the test split (PR 2), the packaging shell with the `.targets` picker (PR 3), and the release (PR 4).

## What's in this PR

- New `packages/selenium/legacy-webdriver/Deque.AxeCore.Selenium.LegacyWebDriver.csproj` — compiles existing sources against `Selenium.WebDriver` 4.4.0.
- New `packages/selenium/new-webdriver/Deque.AxeCore.Selenium.NewWebDriver.csproj` — compiles existing sources against `Selenium.WebDriver` 4.44.0.
- Both variants set `AssemblyName=Deque.AxeCore.Selenium`, `RootNamespace=Deque.AxeCore.Selenium`, and `IsPackable=false`. They link sources and embedded JS resources from `packages/selenium/src/` rather than duplicating files.
- Both wired into `Deque.AxeCore.sln` under the existing `selenium` solution folder.

## What's *not* in this PR

- The existing `packages/selenium/src/Deque.AxeCore.Selenium.csproj` is untouched. It still packs the existing single-Selenium-pin package.
- No source, test, CI, or packaging changes. (Those land in PRs 2 and 3.)

## Verification

All three `selenium` csprojs build clean (Release, `net471` + `netstandard2.0`). The two variant DLLs have the same assembly name but reference different Selenium identities, which is the whole point of this PR:

| Variant | Referenced assembly |
|---|---|
| LegacyWebDriver | `WebDriver, Version=4.0.0.0, PublicKeyToken=null` |
| NewWebDriver    | `Selenium.WebDriver, Version=4.0.0.0, PublicKeyToken=1c2bd1631853048f` |

## Test plan

- [x] CI builds all three `selenium` projects without warnings.
- [x] Reviewer can run `dotnet build packages/selenium/legacy-webdriver/Deque.AxeCore.Selenium.LegacyWebDriver.csproj -c Release` and `…/new-webdriver/…` locally and both succeed.
- [x] Reviewer confirms the existing `Deque.AxeCore.Selenium` package output (`bin/Release/Deque.AxeCore.Selenium.*.nupkg`) is byte-identical to develop's output — this PR is intended to be inert for the existing package.