### PR TITLE
feat(selenium): pack dual Selenium WebDriver variants with .targets picker

### DIFF
--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -7,6 +7,12 @@ Automated web accessibility testing with .NET, C#, and Selenium. Wraps the [axe-
 
 Compatible with .NET Standard 2.0+, .NET Framework 4.7.1+, and .NET Core 2.0+.
 
+## Selenium.WebDriver compatibility
+
+This package supports `Selenium.WebDriver` 4.4.0 and newer, including the 4.44.0+ releases that renamed the underlying assembly from `WebDriver.dll` to `Selenium.WebDriver.dll`. The right variant of `Deque.AxeCore.Selenium.dll` is selected automatically at build time based on which `Selenium.WebDriver` your project resolves — no per-consumer configuration required.
+
+> **`packages.config` is not supported.** The auto-selection relies on an MSBuild `.targets` file that NuGet only imports for projects using `PackageReference`. Legacy `.NET Framework` projects still on `packages.config` should migrate to `PackageReference`, or pin `Selenium.WebDriver` to a version `<4.44.0`.
+
 This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
 
 ## Getting Started

--- a/packages/selenium/README.md
+++ b/packages/selenium/README.md
@@ -11,7 +11,7 @@ Compatible with .NET Standard 2.0+, .NET Framework 4.7.1+, and .NET Core 2.0+.
 
 This package supports `Selenium.WebDriver` 4.4.0 and newer, including the 4.44.0+ releases that renamed the underlying assembly from `WebDriver.dll` to `Selenium.WebDriver.dll`. The right variant of `Deque.AxeCore.Selenium.dll` is selected automatically at build time based on which `Selenium.WebDriver` your project resolves — no per-consumer configuration required.
 
-> **`packages.config` is not supported.** The auto-selection relies on an MSBuild `.targets` file that NuGet only imports for projects using `PackageReference`. Legacy `.NET Framework` projects still on `packages.config` should migrate to `PackageReference`, or pin `Selenium.WebDriver` to a version `<4.44.0`.
+> **`packages.config` is not supported.** The auto-selection relies on an MSBuild `.targets` file that NuGet only imports for projects using `PackageReference`. Legacy `.NET Framework` projects still on `packages.config` should migrate to `PackageReference`. If you cannot migrate yet, stay on a pre-picker version of `Deque.AxeCore.Selenium` (or another supported approach), rather than pinning `Selenium.WebDriver` alone.
 
 This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
 

--- a/packages/selenium/src/Deque.AxeCore.Selenium.csproj
+++ b/packages/selenium/src/Deque.AxeCore.Selenium.csproj
@@ -18,6 +18,23 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
+    <!--
+      This project does not produce its own compiled output. Instead, it packages the
+      pre-compiled DLLs from the LegacyWebDriver and NewWebDriver sibling projects
+      (one referencing each post-rename Selenium.WebDriver assembly identity) along with
+      a .targets picker that selects the matching variant at consume time.
+    -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!--
+      NU5100: variant DLLs intentionally live in variants/ not lib/ — the .targets
+      picker injects the right one as a Reference at consume time.
+      NU5128: no compile output means some target frameworks have no assemblies in
+      lib/, which is expected for a pack-only shell.
+    -->
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+
     <!-- Do not update this by-hand; updates are automated via the create-release workflow -->
     <VersionPrefix>4.11.3</VersionPrefix>
     <VersionSuffix>development</VersionSuffix>
@@ -29,28 +46,56 @@
     <None Include="../README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
+  <!--
+    Build the two variants so their DLLs exist when we pack, but do NOT consume their
+    output as a build reference (we have no sources to compile here) and do NOT
+    propagate their package dependencies — we declare those explicitly below.
+  -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <ProjectReference Include="..\legacy-webdriver\Deque.AxeCore.Selenium.LegacyWebDriver.csproj"
+                      PrivateAssets="all"
+                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\new-webdriver\Deque.AxeCore.Selenium.NewWebDriver.csproj"
+                      PrivateAssets="all"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!--
+    Dependencies that the variants need at runtime. Declared here so they propagate to
+    consumers of the .nupkg. Selenium.WebDriver's minimum is 4.4.0; consumers may resolve
+    a higher version (e.g. 4.44+) and the .targets picker will select the matching variant.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.4.0" />
-
-
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../commons/src/Deque.AxeCore.Commons.csproj" />
   </ItemGroup>
 
+  <!--
+    Pack the variant DLLs alongside an MSBuild .targets file that selects between them
+    based on the Selenium.WebDriver identity the consumer has resolved at restore time.
+  -->
   <ItemGroup>
-    <EmbeddedResource Include="Resources\legacyScan.js" />
-    <EmbeddedResource Include="Resources\storeChunk.js" />
-    <EmbeddedResource Include="Resources\branding.js" />
-    <EmbeddedResource Include="Resources\allowIframeUnsafe.js" />
-    <EmbeddedResource Include="Resources\runPartialExists.js" />
-    <EmbeddedResource Include="Resources\getFrameContexts.js" />
-    <EmbeddedResource Include="Resources\shadowSelect.js" />
-    <EmbeddedResource Include="Resources\runPartial.js" />
-    <EmbeddedResource Include="Resources\finishRun.js" />
-  </ItemGroup>
+    <None Include="..\legacy-webdriver\bin\$(Configuration)\net471\Deque.AxeCore.Selenium.dll"
+          Pack="true" PackagePath="variants\legacy\net471\Deque.AxeCore.Selenium.dll" Visible="false" />
+    <None Include="..\legacy-webdriver\bin\$(Configuration)\netstandard2.0\Deque.AxeCore.Selenium.dll"
+          Pack="true" PackagePath="variants\legacy\netstandard2.0\Deque.AxeCore.Selenium.dll" Visible="false" />
+    <None Include="..\new-webdriver\bin\$(Configuration)\net471\Deque.AxeCore.Selenium.dll"
+          Pack="true" PackagePath="variants\new\net471\Deque.AxeCore.Selenium.dll" Visible="false" />
+    <None Include="..\new-webdriver\bin\$(Configuration)\netstandard2.0\Deque.AxeCore.Selenium.dll"
+          Pack="true" PackagePath="variants\new\netstandard2.0\Deque.AxeCore.Selenium.dll" Visible="false" />
 
+    <None Include="build\Deque.AxeCore.Selenium.targets"
+          Pack="true" PackagePath="build\Deque.AxeCore.Selenium.targets" />
+    <None Include="buildTransitive\Deque.AxeCore.Selenium.targets"
+          Pack="true" PackagePath="buildTransitive\Deque.AxeCore.Selenium.targets" />
+
+    <!-- lib/ placeholders — NuGet requires at least an empty marker per TFM. -->
+    <None Include="_._" Pack="true" PackagePath="lib\net471\_._" Visible="false" />
+    <None Include="_._" Pack="true" PackagePath="lib\netstandard2.0\_._" Visible="false" />
+  </ItemGroup>
 </Project>

--- a/packages/selenium/src/build/Deque.AxeCore.Selenium.targets
+++ b/packages/selenium/src/build/Deque.AxeCore.Selenium.targets
@@ -19,10 +19,10 @@
     <ItemGroup>
       <_DequeAxeCoreSeleniumResolvedSeleniumNew
         Include="@(ResolvedCompileFileDefinitions)"
-        Condition=" '%(Filename)' == 'Selenium.WebDriver' " />
+        Condition=" '%(ResolvedCompileFileDefinitions.Filename)' == 'Selenium.WebDriver' " />
       <_DequeAxeCoreSeleniumResolvedSeleniumLegacy
         Include="@(ResolvedCompileFileDefinitions)"
-        Condition=" '%(Filename)' == 'WebDriver' " />
+        Condition=" '%(ResolvedCompileFileDefinitions.Filename)' == 'WebDriver' " />
     </ItemGroup>
 
     <PropertyGroup>

--- a/packages/selenium/src/build/Deque.AxeCore.Selenium.targets
+++ b/packages/selenium/src/build/Deque.AxeCore.Selenium.targets
@@ -1,0 +1,53 @@
+<Project>
+  <!--
+    Auto-imported by NuGet when a project consumes Deque.AxeCore.Selenium.
+
+    Selenium.WebDriver 4.44.0 renamed its compiled assembly from WebDriver.dll
+    to Selenium.WebDriver.dll. The Deque.AxeCore.Selenium.nupkg ships two
+    pre-compiled variants of Deque.AxeCore.Selenium.dll — one referencing each
+    Selenium identity. This file inspects which Selenium assembly the consumer's
+    project resolved at restore time and injects a <Reference> to the matching
+    variant.
+
+    Default if neither is resolved (or both, somehow): "new" (Selenium 4.44+).
+  -->
+
+  <Target Name="_DequeAxeCoreSeleniumSelectVariant"
+          AfterTargets="ResolvePackageAssets"
+          BeforeTargets="ResolveAssemblyReferences">
+
+    <ItemGroup>
+      <_DequeAxeCoreSeleniumResolvedSeleniumNew
+        Include="@(ResolvedCompileFileDefinitions)"
+        Condition=" '%(Filename)' == 'Selenium.WebDriver' " />
+      <_DequeAxeCoreSeleniumResolvedSeleniumLegacy
+        Include="@(ResolvedCompileFileDefinitions)"
+        Condition=" '%(Filename)' == 'WebDriver' " />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_DequeAxeCoreSeleniumVariant>new</_DequeAxeCoreSeleniumVariant>
+      <_DequeAxeCoreSeleniumVariant
+        Condition=" '@(_DequeAxeCoreSeleniumResolvedSeleniumLegacy)' != '' AND '@(_DequeAxeCoreSeleniumResolvedSeleniumNew)' == '' "
+      >legacy</_DequeAxeCoreSeleniumVariant>
+
+      <_DequeAxeCoreSeleniumVariantTfm>netstandard2.0</_DequeAxeCoreSeleniumVariantTfm>
+      <_DequeAxeCoreSeleniumVariantTfm
+        Condition=" $(TargetFramework.StartsWith('net4')) "
+      >net471</_DequeAxeCoreSeleniumVariantTfm>
+
+      <_DequeAxeCoreSeleniumVariantPath>$(MSBuildThisFileDirectory)..\variants\$(_DequeAxeCoreSeleniumVariant)\$(_DequeAxeCoreSeleniumVariantTfm)\Deque.AxeCore.Selenium.dll</_DequeAxeCoreSeleniumVariantPath>
+    </PropertyGroup>
+
+    <Error
+      Condition=" !Exists('$(_DequeAxeCoreSeleniumVariantPath)') "
+      Text="Deque.AxeCore.Selenium: could not locate variant '$(_DequeAxeCoreSeleniumVariant)' for TargetFramework '$(TargetFramework)' at $(_DequeAxeCoreSeleniumVariantPath). This is a packaging bug — please file an issue." />
+
+    <ItemGroup>
+      <Reference Include="Deque.AxeCore.Selenium">
+        <HintPath>$(_DequeAxeCoreSeleniumVariantPath)</HintPath>
+        <Private>true</Private>
+      </Reference>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/packages/selenium/src/buildTransitive/Deque.AxeCore.Selenium.targets
+++ b/packages/selenium/src/buildTransitive/Deque.AxeCore.Selenium.targets
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Transitive consumers see the same picker logic as direct consumers. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Deque.AxeCore.Selenium.targets" />
+</Project>

--- a/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
+++ b/packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj
@@ -39,7 +39,8 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="Selenium.Support" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Selenium.Support" Version="4.44.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
@@ -48,7 +49,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\Deque.AxeCore.Selenium.csproj" />
+    <!--
+      The src csproj is now a pack-only shell that bundles both Selenium variants.
+      Reference the NewWebDriver variant directly so the existing integration suite
+      continues to exercise real code against modern Selenium (4.44+). Per-variant
+      integration coverage is out of scope for the dual-Selenium work; unit-test
+      coverage of both variants is provided by the variant test projects.
+    -->
+    <ProjectReference Include="..\new-webdriver\Deque.AxeCore.Selenium.NewWebDriver.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

PR 3a of 4 toward dual-Selenium support (tracking issue #252; design in [the gist](https://gist.github.com/scottmries/359d7a8e5e92b4f536e7240e40c6b3a8)). Converts the existing `Deque.AxeCore.Selenium` csproj into a pack-only shell that bundles both pre-compiled variants from #251 and an MSBuild `.targets` picker that selects between them at consume time.

After this PR lands, a consumer can install `Deque.AxeCore.Selenium` and use `Selenium.WebDriver` 4.4.0 *or* 4.44.0+ — the package picks the right variant transparently. Fixes #248.

## What changes

- **`packages/selenium/src/Deque.AxeCore.Selenium.csproj`** — converted from a compiling project to a pack-only shell:
  - No longer compiles its own sources (`EnableDefaultCompileItems=false`, `IncludeBuildOutput=false`).
  - `ProjectReference`s both LegacyWebDriver and NewWebDriver variants with `PrivateAssets="all" ReferenceOutputAssembly="false"` so they build first but don't propagate as build-time refs.
  - Declares `Selenium.WebDriver` 4.4.0 + `Newtonsoft.Json` as transitive deps for the consumer.
  - Packs variant DLLs into `variants/legacy/<tfm>/Deque.AxeCore.Selenium.dll` and `variants/new/<tfm>/Deque.AxeCore.Selenium.dll`.
  - Packs `lib/<tfm>/_._` placeholders so NuGet recognizes it as a library package.
  - Suppresses `NU5100` / `NU5128` (intentional non-`lib/` layout for the picker mechanism).

- **`packages/selenium/src/build/Deque.AxeCore.Selenium.targets`** *(new)* — the picker, auto-imported by NuGet for `PackageReference` consumers. Hooks `AfterTargets=ResolvePackageAssets`, inspects `@(ResolvedCompileFileDefinitions)` for `Selenium.WebDriver.dll` (new) or `WebDriver.dll` (legacy), and injects a `<Reference>` to the matching variant. Defaults to `new` if neither resolves.

- **`packages/selenium/src/buildTransitive/Deque.AxeCore.Selenium.targets`** *(new)* — `<Import>`s the file in `build/` so transitive consumers get the same dispatch with one source of truth.

- **`packages/selenium/test/Deque.AxeCore.Selenium.Test.csproj`** — `ProjectReference` retargeted from the now-pack-only src csproj to `..\new-webdriver\…`. Picks up `Microsoft.Bcl.AsyncInterfaces` 8.0.0 and bumps `Selenium.Support` to 4.44.0 (Selenium 4.44+ surfaces `IAsyncDisposable`).

- **`packages/selenium/README.md`** — adds a "Selenium.WebDriver compatibility" section documenting the auto-selection and the `packages.config` limitation.

## What's *not* in this PR

- Acceptance smoke CI workflow — that's PR 3b. (Manual end-to-end verification recorded below stands in for it until then.)
- Release — that's PR 4.

## Verification

Built end-to-end locally:

| Throwaway consumer       | Resulting `Deque.AxeCore.Selenium.dll` references |
|---|---|
| `Selenium.WebDriver 4.4.0` + `Deque.AxeCore.Selenium` (this PR) | `WebDriver, Version=4.0.0.0, PublicKeyToken=null` (legacy variant) |
| `Selenium.WebDriver 4.44.0` + `Deque.AxeCore.Selenium` (this PR) | `Selenium.WebDriver, Version=4.0.0.0, PublicKeyToken=1c2bd1631853048f` (new variant) |

`dotnet build Deque.AxeCore.sln -c Release` is clean (0 errors).

Resulting nupkg layout:

```
variants/legacy/net471/Deque.AxeCore.Selenium.dll
variants/legacy/netstandard2.0/Deque.AxeCore.Selenium.dll
variants/new/net471/Deque.AxeCore.Selenium.dll
variants/new/netstandard2.0/Deque.AxeCore.Selenium.dll
build/Deque.AxeCore.Selenium.targets
buildTransitive/Deque.AxeCore.Selenium.targets
lib/net471/_._
lib/netstandard2.0/_._
LICENSE.txt, NOTICE.txt, README.md
```

## Risks (carried from the gist)

- **`.targets` correctness across IDEs** — verified locally via `dotnet build` CLI. **Manual VS + Rider checklist still required before PR 4 (release).** PR 3b's acceptance smoke covers the CLI build path on every PR; IDE smoke is operator responsibility.
- **`packages.config` consumers** — documented as unsupported in the README. The `.targets` mechanism requires `PackageReference`.
- **`.snupkg` validator** — using standard `lib/<tfm>/_._` markers should keep the symbol validator happy. Fallback (embed symbols in the main `.nupkg`) deferred until/unless the validator complains.
- **IDE caching (Rider)** — will be called out in release notes (PR 4).
- **Strong-naming asymmetry** — out of scope; future constraint.

## Test plan

- [ ] CI green on all existing test suites (commons, playwright, selenium existing, both variant tests).
- [ ] Reviewer can `dotnet pack packages/selenium/src/Deque.AxeCore.Selenium.csproj -c Release` and unzip the resulting `.nupkg` to verify the layout above.
- [ ] Reviewer can build a throwaway consumer against each Selenium version and reflect the resulting binary's referenced assemblies. (PR 3b will automate this.)
- [ ] Reviewer manually opens the solution in Visual Studio and/or Rider, restores, and confirms the picker fires correctly there too. *(Recommended before merging.)*

No QA required