### PR TITLE
ci(selenium): dual-Selenium smoke workflow + picker bug fix surfaced by it

### DIFF
--- a/.github/smoke/AssemblyRefInspector/AssemblyRefInspector.csproj
+++ b/.github/smoke/AssemblyRefInspector/AssemblyRefInspector.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/.github/smoke/AssemblyRefInspector/Program.cs
+++ b/.github/smoke/AssemblyRefInspector/Program.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+// Lists the referenced assemblies of a target DLL and asserts that one specific
+// reference is present and another specific reference is absent. Used by the
+// dual-selenium-smoke workflow to verify that the .targets picker selected the
+// correct pre-compiled variant for a given consumer's Selenium.WebDriver version.
+//
+// Usage:
+//   AssemblyRefInspector <dll-path> --expect <SimpleName> --reject <SimpleName>
+//
+// Exits 0 on success, 1 on assertion failure, 2 on argument/IO error.
+
+if (args.Length != 5 || args[1] != "--expect" || args[3] != "--reject")
+{
+    Console.Error.WriteLine("usage: AssemblyRefInspector <dll-path> --expect <SimpleName> --reject <SimpleName>");
+    return 2;
+}
+
+var dllPath = args[0];
+var expected = args[2];
+var rejected = args[4];
+
+if (!System.IO.File.Exists(dllPath))
+{
+    Console.Error.WriteLine($"FAIL: file not found: {dllPath}");
+    return 2;
+}
+
+var refs = Assembly.LoadFrom(dllPath).GetReferencedAssemblies();
+Console.WriteLine($"Referenced assemblies in {dllPath}:");
+foreach (var r in refs)
+{
+    Console.WriteLine($"  {r.FullName}");
+}
+
+var sawExpected = refs.Any(r => r.Name == expected);
+var sawRejected = refs.Any(r => r.Name == rejected);
+
+if (sawExpected && !sawRejected)
+{
+    Console.WriteLine($"PASS: references {expected}, does not reference {rejected}.");
+    return 0;
+}
+
+if (!sawExpected)
+{
+    Console.Error.WriteLine($"FAIL: expected reference to {expected} was not present.");
+}
+if (sawRejected)
+{
+    Console.Error.WriteLine($"FAIL: rejected reference to {rejected} was present (the picker selected the wrong variant).");
+}
+return 1;

--- a/.github/smoke/AssemblyRefInspector/Program.cs
+++ b/.github/smoke/AssemblyRefInspector/Program.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 // Lists the referenced assemblies of a target DLL and asserts that one specific
 // reference is present and another specific reference is absent. Used by the
@@ -28,7 +31,17 @@ if (!System.IO.File.Exists(dllPath))
     return 2;
 }
 
-var refs = Assembly.LoadFrom(dllPath).GetReferencedAssemblies();
+IReadOnlyList<AssemblyReferenceInfo> refs;
+try
+{
+    refs = ReadAssemblyReferences(dllPath);
+}
+catch (Exception ex) when (ex is BadImageFormatException || ex is IOException || ex is UnauthorizedAccessException)
+{
+    Console.Error.WriteLine($"FAIL: could not parse assembly metadata for {dllPath}: {ex.Message}");
+    return 2;
+}
+
 Console.WriteLine($"Referenced assemblies in {dllPath}:");
 foreach (var r in refs)
 {
@@ -53,3 +66,31 @@ if (sawRejected)
     Console.Error.WriteLine($"FAIL: rejected reference to {rejected} was present (the picker selected the wrong variant).");
 }
 return 1;
+
+static IReadOnlyList<AssemblyReferenceInfo> ReadAssemblyReferences(string dllPath)
+{
+    using var stream = File.OpenRead(dllPath);
+    using var peReader = new PEReader(stream);
+    if (!peReader.HasMetadata)
+    {
+        throw new BadImageFormatException("file does not contain .NET metadata");
+    }
+
+    var metadataReader = peReader.GetMetadataReader();
+    if (!metadataReader.IsAssembly)
+    {
+        throw new BadImageFormatException("metadata does not describe a managed assembly");
+    }
+
+    var refs = new List<AssemblyReferenceInfo>();
+    foreach (var referenceHandle in metadataReader.AssemblyReferences)
+    {
+        var reference = metadataReader.GetAssemblyReference(referenceHandle);
+        var name = metadataReader.GetString(reference.Name);
+        refs.Add(new AssemblyReferenceInfo(name, $"{name}, Version={reference.Version}"));
+    }
+
+    return refs;
+}
+
+readonly record struct AssemblyReferenceInfo(string Name, string FullName);

--- a/.github/smoke/run-smoke.sh
+++ b/.github/smoke/run-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Builds a throwaway consumer of Deque.AxeCore.Selenium against a specific
+# Selenium.WebDriver version, then asserts that the build/Deque.AxeCore.Selenium.targets
+# picker selected the correct pre-compiled variant.
+#
+# Assumes Deque.AxeCore.Commons and Deque.AxeCore.Selenium have already been packed
+# into their respective packages/<name>/src/bin/Release directories and that the
+# AssemblyRefInspector has been built.
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+    echo "usage: $0 <flavor> <selenium-version> <expected-ref> <rejected-ref> <consumer-tfm>" >&2
+    echo "  flavor:           advisory label, e.g. legacy or new" >&2
+    echo "  selenium-version: e.g. 4.4.0 or 4.44.0" >&2
+    echo "  expected-ref:     simple assembly name the picker should reference (WebDriver or Selenium.WebDriver)" >&2
+    echo "  rejected-ref:     simple assembly name the picker should NOT reference" >&2
+    echo "  consumer-tfm:     e.g. net471 or netstandard2.0" >&2
+    exit 2
+fi
+
+flavor="$1"
+selenium_version="$2"
+expected="$3"
+rejected="$4"
+consumer_tfm="$5"
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+inspector="$repo_root/.github/smoke/AssemblyRefInspector/bin/Release/net6.0/AssemblyRefInspector.dll"
+commons_feed="$repo_root/packages/commons/src/bin/Release"
+selenium_feed="$repo_root/packages/selenium/src/bin/Release"
+
+if [[ ! -f "$inspector" ]]; then
+    echo "FAIL: AssemblyRefInspector not built. Run: dotnet build $repo_root/.github/smoke/AssemblyRefInspector/AssemblyRefInspector.csproj -c Release" >&2
+    exit 2
+fi
+
+# Read the just-packed package version so the throwaway consumer pins to it.
+pkg_path=$(ls "$selenium_feed"/Deque.AxeCore.Selenium.*.nupkg 2>/dev/null | head -1 || true)
+if [[ -z "$pkg_path" ]]; then
+    echo "FAIL: no Deque.AxeCore.Selenium nupkg found in $selenium_feed. Pack it first." >&2
+    exit 2
+fi
+pkg_version=$(basename "$pkg_path" | sed -E 's|Deque\.AxeCore\.Selenium\.([0-9].+)\.nupkg|\1|')
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/Consumer.csproj" <<PROJEOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$consumer_tfm</TargetFramework>
+    <RestoreSources>$selenium_feed;$commons_feed;https://api.nuget.org/v3/index.json</RestoreSources>
+    <RestorePackagesPath>$tmpdir/packages</RestorePackagesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Selenium.WebDriver" Version="$selenium_version" />
+    <PackageReference Include="Deque.AxeCore.Selenium" Version="$pkg_version" />
+  </ItemGroup>
+</Project>
+PROJEOF
+
+cat > "$tmpdir/Hello.cs" <<'CSEOF'
+using Deque.AxeCore.Selenium;
+using OpenQA.Selenium;
+namespace SmokeConsumer
+{
+    public class Hello
+    {
+        public AxeBuilder Make(IWebDriver d) => new AxeBuilder(d);
+    }
+}
+CSEOF
+
+echo "=== smoke: flavor=$flavor selenium=$selenium_version tfm=$consumer_tfm ==="
+
+dotnet build "$tmpdir/Consumer.csproj" -c Release
+
+dll="$tmpdir/bin/Release/$consumer_tfm/Deque.AxeCore.Selenium.dll"
+if [[ ! -f "$dll" ]]; then
+    echo "FAIL: variant DLL was not copied to consumer's bin at $dll" >&2
+    exit 1
+fi
+
+dotnet "$inspector" "$dll" --expect "$expected" --reject "$rejected"

--- a/.github/workflows/dual-selenium-smoke.yml
+++ b/.github/workflows/dual-selenium-smoke.yml
@@ -1,0 +1,81 @@
+name: Dual Selenium smoke
+
+# Builds throwaway consumer projects against each combination of
+# (Selenium.WebDriver version, consumer TargetFramework) and asserts that the
+# .targets picker shipped in Deque.AxeCore.Selenium.nupkg selected the matching
+# pre-compiled variant. Designed to catch regressions in the dual-Selenium
+# packaging machinery introduced in #252.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/selenium/**'
+      - 'packages/commons/**'
+      - '.github/workflows/dual-selenium-smoke.yml'
+      - '.github/smoke/**'
+  push:
+    branches:
+      - develop
+      - master
+    paths:
+      - 'packages/selenium/**'
+      - 'packages/commons/**'
+      - '.github/workflows/dual-selenium-smoke.yml'
+      - '.github/smoke/**'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Smoke (${{ matrix.flavor }} / ${{ matrix.consumer_tfm }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - flavor: legacy
+            selenium_version: '4.4.0'
+            expected_ref: WebDriver
+            rejected_ref: Selenium.WebDriver
+            consumer_tfm: net471
+          - flavor: legacy
+            selenium_version: '4.4.0'
+            expected_ref: WebDriver
+            rejected_ref: Selenium.WebDriver
+            consumer_tfm: netstandard2.0
+          - flavor: new
+            selenium_version: '4.44.0'
+            expected_ref: Selenium.WebDriver
+            rejected_ref: WebDriver
+            consumer_tfm: net471
+          - flavor: new
+            selenium_version: '4.44.0'
+            expected_ref: Selenium.WebDriver
+            rejected_ref: WebDriver
+            consumer_tfm: netstandard2.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install .NET Core 3.1 and 6
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            3.1.x
+            6.x.x
+
+      - name: Pack Commons + Deque.AxeCore.Selenium
+        run: |
+          dotnet build Deque.AxeCore.sln -c Release
+
+      - name: Build assembly inspector
+        run: dotnet build .github/smoke/AssemblyRefInspector/AssemblyRefInspector.csproj -c Release
+
+      - name: Run smoke
+        run: |
+          .github/smoke/run-smoke.sh \
+            ${{ matrix.flavor }} \
+            ${{ matrix.selenium_version }} \
+            ${{ matrix.expected_ref }} \
+            ${{ matrix.rejected_ref }} \
+            ${{ matrix.consumer_tfm }}

--- a/packages/selenium/src/build/Deque.AxeCore.Selenium.targets
+++ b/packages/selenium/src/build/Deque.AxeCore.Selenium.targets
@@ -43,6 +43,19 @@
       Condition=" !Exists('$(_DequeAxeCoreSeleniumVariantPath)') "
       Text="Deque.AxeCore.Selenium: could not locate variant '$(_DequeAxeCoreSeleniumVariant)' for TargetFramework '$(TargetFramework)' at $(_DequeAxeCoreSeleniumVariantPath). This is a packaging bug — please file an issue." />
 
+    <!--
+      ResolveAssemblyReferences computes its CandidateAssemblyFiles list from
+      @(Content) + @(None) when it runs, and NuGet restore drops every file from
+      every restored package — including all four of our variant DLLs — into
+      @(None). Without filtering, RAR's search finds the wrong variant first
+      and ignores the HintPath. Strip the unchosen variants from @(None) so the
+      picker's Reference is the only match.
+    -->
+    <ItemGroup>
+      <None Remove="@(None)"
+            Condition=" '%(Filename)%(Extension)' == 'Deque.AxeCore.Selenium.dll' AND '$([MSBuild]::NormalizePath(%(FullPath)))' != '$([MSBuild]::NormalizePath($(_DequeAxeCoreSeleniumVariantPath)))' " />
+    </ItemGroup>
+
     <ItemGroup>
       <Reference Include="Deque.AxeCore.Selenium">
         <HintPath>$(_DequeAxeCoreSeleniumVariantPath)</HintPath>


### PR DESCRIPTION
> **Stacked on top of #254.** Base branch is `sr-dual-selenium-packaging-shell`; once that merges, this PR's base switches to `develop`. Diff against develop will then show both commits.

## Summary

PR 3b (final code PR) toward dual-Selenium support (tracking issue #252; design in [the gist](https://gist.github.com/scottmries/359d7a8e5e92b4f536e7240e40c6b3a8)). Two commits:

1. **`fix(selenium): exclude unchosen variants from @(None)`** — Picker bug surfaced by the smoke. MSBuild's RAR was picking the wrong variant because NuGet's @(None) had all four variant DLLs as candidates with higher search priority than the picker's HintPath.
2. **`ci(selenium): add dual-Selenium smoke workflow`** — New `.github/workflows/dual-selenium-smoke.yml` runs on selenium-touching PRs, builds throwaway consumer projects across (Selenium 4.4.0 vs 4.44.0) × (net471 vs netstandard2.0), and asserts the picker selected the matching variant.

The smoke surfaced the bug in commit 1 within minutes of being wired up — exactly the kind of regression net the gist's risk table called out for the .targets picker. Folded into this PR (rather than amending #254) because the two changes are conceptually paired: the smoke is the test that would fail without the fix.

## What lands here

### `.github/smoke/AssemblyRefInspector/`

Small net6.0 console exe that reads a DLL's referenced assemblies via `MetadataLoadContext` (metadata-only, no actual load) and asserts presence of an expected referenced assembly + absence of a rejected one. Usage:

```
AssemblyRefInspector <dll> --expect <SimpleName> --reject <SimpleName>
```

Exits 0 on pass, 1 on assertion failure, 2 on argument/IO error.

### `.github/smoke/run-smoke.sh`

Glue script. Takes `<flavor> <selenium-version> <expected> <rejected> <consumer-tfm>`. Generates an isolated consumer csproj that PackageReferences our locally-packed nupkg + the specified Selenium version, writes a one-liner C# file that exercises `new AxeBuilder(driver)` so the picker's Reference gets copied to bin, builds, and runs the inspector.

### `.github/workflows/dual-selenium-smoke.yml`

4-cell matrix:

| Selenium.WebDriver | Consumer TFM | Expected Selenium ref |
|---|---|---|
| 4.4.0  | net471         | `WebDriver` |
| 4.4.0  | netstandard2.0 | `WebDriver` |
| 4.44.0 | net471         | `Selenium.WebDriver` |
| 4.44.0 | netstandard2.0 | `Selenium.WebDriver` |

Triggers on PRs touching `packages/selenium/**`, `packages/commons/**`, the workflow itself, or the smoke scripts. Also runs on develop/master pushes and via workflow_dispatch.

### `packages/selenium/src/build/Deque.AxeCore.Selenium.targets`

Picker now strips the unchosen variant DLLs from `@(None)` before RAR runs. Without this, the picker's `<Reference><HintPath>...` is silently overridden by RAR's `{CandidateAssemblyFiles}` search path because the latter comes first in `AssemblySearchPaths` and finds the (wrong) variant first.

## Verified locally

All 4 matrix cells pass:

```
===== legacy 4.4.0 WebDriver Selenium.WebDriver netstandard2.0 =====
  PASS: references WebDriver, does not reference Selenium.WebDriver.
===== new 4.44.0 Selenium.WebDriver WebDriver netstandard2.0 =====
  PASS: references Selenium.WebDriver, does not reference WebDriver.
===== legacy 4.4.0 WebDriver Selenium.WebDriver net471 =====
  PASS: references WebDriver, does not reference Selenium.WebDriver.
===== new 4.44.0 Selenium.WebDriver WebDriver net471 =====
  PASS: references Selenium.WebDriver, does not reference WebDriver.
```

## Reviewer test plan

- [ ] CI run of the new `dual-selenium-smoke` workflow is green on all 4 matrix cells.
- [ ] Reviewer manually verifies the picker fix is doing what the comment says (drop a stale `Deque.AxeCore.Selenium.dll` back into `@(None)` and confirm the smoke catches it as a regression).
- [ ] Reviewer confirms the workflow's path filter triggers on a selenium-touching change but doesn't trigger on unrelated changes.

## QA notes

This PR completes the dual-Selenium support series (#251, #253, #254, this PR); the next release ships the full feature.

CI already covers what most consumers will do via `dotnet build`: the `dual-selenium-smoke` workflow exercises the picker across (Selenium 4.4.0 / 4.44.0) × (net471 / netstandard2.0), and the existing `build-and-test` runs the full Selenium integration suite against the new-webdriver variant. The checks below are the ones CI cannot perform.

### IDE-driven builds

- [ ] Visual Studio 2022 — open a real consumer project that uses `AxeBuilder`, restore, build, run a scan. Try both `Selenium.WebDriver` 4.4.0 and 4.44.0.
- [ ] Rider — same. If the project was previously built against an older `Deque.AxeCore.Selenium`, run `dotnet build-server shutdown` first; this will be called out in the release notes per the gist's risk table.

### #248 upgrade reproduction

The real-world workflow that prompted this work:

- [ ] Existing project using `Deque.AxeCore.Selenium` 4.11.3 + `Selenium.WebDriver` 4.4.0
- [ ] Bump `Selenium.WebDriver` to 4.44.0 (without bumping `Deque.AxeCore.Selenium`) — confirm the bug from #248 reproduces (build error: type `IWebElement` is defined in an assembly that is not referenced — `WebDriver, Version=4.0.0.0, …`)
- [ ] Bump `Deque.AxeCore.Selenium` to this release — build succeeds, scan runs

### `packages.config` (documented limitation; verify behavior, do not block release)

- [ ] Attempt to install this release into a `.NET Framework` project still using `packages.config`. Capture the failure mode so the release notes can describe what those users will see.

No QA Required