### PR TITLE
feat(playwright): use small viewport on blank page

### DIFF
--- a/packages/playwright/src/AxeCoreWrapper/DefaultAxeCoreWrapper.cs
+++ b/packages/playwright/src/AxeCoreWrapper/DefaultAxeCoreWrapper.cs
@@ -269,9 +269,9 @@ namespace Deque.AxeCore.Playwright.AxeCoreWrapper
             {
                 throw new Exception("Could not locate browser associated with page");
             }
-            
+
             var blankPage = await browser.NewPageAsync(
-                    new BrowserNewPageOptions() { ViewportSize = new ViewportSize() { Width = 1, Height = 1}}
+                    new BrowserNewPageOptions() { ViewportSize = new ViewportSize() { Width = 1, Height = 1 } }
             ).ConfigureAwait(false);
 
             try

--- a/packages/playwright/src/AxeCoreWrapper/DefaultAxeCoreWrapper.cs
+++ b/packages/playwright/src/AxeCoreWrapper/DefaultAxeCoreWrapper.cs
@@ -269,7 +269,11 @@ namespace Deque.AxeCore.Playwright.AxeCoreWrapper
             {
                 throw new Exception("Could not locate browser associated with page");
             }
-            var blankPage = await browser.NewPageAsync().ConfigureAwait(false);
+            
+            var blankPage = await browser.NewPageAsync(
+                    new BrowserNewPageOptions() { ViewportSize = new ViewportSize() { Width = 1, Height = 1}}
+            ).ConfigureAwait(false);
+
             try
             {
                 await ConfigureAxe(blankPage.MainFrame).ConfigureAwait(false);


### PR DESCRIPTION
## Details
This should stop the new page being created from flash-banging people when not running tests in headless mode.

Closes Issue:  #256