### PR TITLE
fix(selenium): open finishRun page in a 1x1 window to avoid flash (#259)

### DIFF
--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -332,8 +332,9 @@ namespace Deque.AxeCore.Selenium
 
             try
             {
-                // create an isolated page
-                _webDriver.ExecuteScript("window.open('about:blank', '_blank')");
+                // create an isolated page in a 1x1 window so it does not visibly
+                // flash on screen when running in non-headless mode (parity with #257)
+                _webDriver.ExecuteScript("window.open('about:blank', '_blank', 'width=1,height=1')");
                 _webDriver.SwitchTo().Window(_webDriver.WindowHandles.Last());
                 _webDriver.Navigate().GoToUrl("about:blank");
             }
@@ -345,31 +346,35 @@ namespace Deque.AxeCore.Selenium
                 );
             }
 
-            ConfigureAxe();
-
-            var serializedPartials = JsonConvert.SerializeObject(partialResults, AxeJsonSerializerSettings.Default);
-            int sizeLimit = 10_000_000;
-
-            while (!string.IsNullOrEmpty(serializedPartials))
+            try
             {
-                int chunkSize = sizeLimit;
-                if (chunkSize > serializedPartials.Length)
+                ConfigureAxe();
+
+                var serializedPartials = JsonConvert.SerializeObject(partialResults, AxeJsonSerializerSettings.Default);
+                int sizeLimit = 10_000_000;
+
+                while (!string.IsNullOrEmpty(serializedPartials))
                 {
-                    chunkSize = serializedPartials.Length;
+                    int chunkSize = sizeLimit;
+                    if (chunkSize > serializedPartials.Length)
+                    {
+                        chunkSize = serializedPartials.Length;
+                    }
+                    String chunk = serializedPartials.Substring(0, chunkSize);
+                    serializedPartials = serializedPartials.Substring(chunkSize);
+                    _webDriver.ExecuteScript(EmbeddedResourceProvider.ReadEmbeddedFile("storeChunk.js"), chunk);
                 }
-                String chunk = serializedPartials.Substring(0, chunkSize);
-                serializedPartials = serializedPartials.Substring(chunkSize);
-                _webDriver.ExecuteScript(EmbeddedResourceProvider.ReadEmbeddedFile("storeChunk.js"), chunk);
+                // grab result ...
+                var result = _webDriver.ExecuteAsyncScript(EmbeddedResourceProvider.ReadEmbeddedFile("finishRun.js"), options);
+
+                return JObject.FromObject(result);
             }
-            // grab result ...
-            var result = _webDriver.ExecuteAsyncScript(EmbeddedResourceProvider.ReadEmbeddedFile("finishRun.js"), options);
-
-            // ... close the new window and go back
-            _webDriver.Close();
-            _webDriver.SwitchTo().Window(originalWindowHandle);
-
-            return JObject.FromObject(result);
-
+            finally
+            {
+                // ... close the new window and go back
+                _webDriver.Close();
+                _webDriver.SwitchTo().Window(originalWindowHandle);
+            }
         }
 
         private JObject AnalyzeAxeLegacy(object rawContextArg)

--- a/packages/selenium/src/AxeBuilder.cs
+++ b/packages/selenium/src/AxeBuilder.cs
@@ -372,8 +372,14 @@ namespace Deque.AxeCore.Selenium
             finally
             {
                 // ... close the new window and go back
-                _webDriver.Close();
-                _webDriver.SwitchTo().Window(originalWindowHandle);
+                try
+                {
+                    _webDriver.Close();
+                }
+                finally
+                {
+                    _webDriver.SwitchTo().Window(originalWindowHandle);
+                }
             }
         }
 


### PR DESCRIPTION
## Details

`IsolatedFinishRun` in [AxeBuilder.cs](packages/selenium/src/AxeBuilder.cs#L328-L378) opened a full-size `about:blank` window for `finishRun`. In non-headless mode that window grabs focus and renders blank white — the same "flash-bang" fixed for the Playwright wrapper in #257 (#256). This brings the Selenium wrapper to parity.

**Changes:**
- **Flash fix:** open the isolated page as a 1×1 window via the `window.open` features string — `window.open('about:blank', '_blank', 'width=1,height=1')` — so it never renders full-screen. This is the Selenium analog of Playwright's 1×1 `ViewportSize` mitigation, sizing the window at creation so it's small from the first paint.
- **Cleanup hardening (also parity with #257):** wrap `ConfigureAxe` → chunking → `finishRun.js` in a `try`, with `_webDriver.Close()` + switch back to the original window handle in a `finally`. A `finishRun` error can no longer leak the extra window or strand the driver on the blank page.

The touched chunk-loop lines normalized CRLF→LF as part of the re-indent into the new `try` block (consistent with the direction of #258).

### Verification
- `dotnet build` of the Selenium project succeeds (0 warnings, 0 errors).
- `RunPartial/FinishRunTests` pass on Firefox (`ShouldIsolateCallToFinishRun`, `ShouldHaveSameResultsAsLegacy`), exercising the modified `IsolatedFinishRun` end-to-end. Chrome cases were blocked locally only by a ChromeDriver/Chrome version mismatch (env), not by this change — CI runs matched versions.

> Note: the flash is a visual artifact with no automated test (none was added in #257 either); worth a manual non-headless eyeball before release.

Closes #259