### PR TITLE
fix: Update axe-core to v4.12.1

### DIFF
--- a/packages/commons/src/package-lock.json
+++ b/packages/commons/src/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "axe-core": "^4.12.0"
+        "axe-core": "^4.12.1"
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
-      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "axe-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
-      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="
     }
   }
 }

--- a/packages/commons/src/package.json
+++ b/packages/commons/src/package.json
@@ -3,6 +3,6 @@
   "repository": {},
   "license": "MIT",
   "dependencies": {
-    "axe-core": "^4.12.0"
+    "axe-core": "^4.12.1"
   }
 }


### PR DESCRIPTION
This pull request updates the version of [`axe-core`](https://npmjs.org/axe-core) to v4.12.1.

This PR was opened by a robot :robot: :tada:.