### PR TITLE
fix(selenium): stop generating empty symbol package that blocks Playwright publish (#266)

### DIFF
--- a/packages/selenium/src/Deque.AxeCore.Selenium.csproj
+++ b/packages/selenium/src/Deque.AxeCore.Selenium.csproj
@@ -14,8 +14,13 @@
 
     <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!--
+      This is a pack-only shell with IncludeBuildOutput=false (see below), so it produces no
+      compiled assembly and therefore no .pdb. Generating a symbol package here yields an empty
+      .snupkg, which nuget.org rejects with HTTP 400 ("does not contain any symbol (.pdb) files"),
+      failing the publish step. Symbols live with the variant DLLs' own builds, not this shell.
+    -->
+    <IncludeSymbols>false</IncludeSymbols>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
     <!--


### PR DESCRIPTION
## Details

The canary publish job has failed on every run since build 121 (2026-05-21), leaving **Deque.AxeCore.Playwright frozen at `4.11.3-alpha.120`** while Commons/Selenium advanced to `alpha.126`.

**Root cause:** #254 turned the Selenium package into a pack-only shell (`IncludeBuildOutput=false`) — it ships pre-built variant DLLs as content and has no compiled assembly of its own — but left `IncludeSymbols=true` / `SymbolPackageFormat=snupkg` in place. With no assembly there's no `.pdb`, so `dotnet pack` emits an **empty `.snupkg`**. `dotnet nuget push` auto-pushes that symbol package, and nuget.org rejects it with `HTTP 400 (The package does not contain any symbol (.pdb) files.)`. That fails the Selenium publish step, and because [publish-nuget-packages.yml](.github/workflows/publish-nuget-packages.yml) is fail-fast and sequential with Playwright pushed **last**, the Playwright step is **skipped** every run.

Builds ≤120 worked because Selenium still compiled a real assembly, so its symbol package had `.pdb`s and the push succeeded.

**Fix:** set `IncludeSymbols=false` on the Selenium shell project. It has no symbols to publish, so no empty `.snupkg` is produced, the Selenium push succeeds, and the Playwright step runs again. The main `.nupkg` is unchanged.

Closes #266

QA notes: Verified locally — `dotnet pack packages/selenium/src/Deque.AxeCore.Selenium.csproj -c Release` now produces only `Deque.AxeCore.Selenium.*.nupkg` (no empty `.snupkg`), `dotnet build` of the project is clean, and Commons still packs a valid `.snupkg` containing `.pdb`s (unaffected). After merge to `develop`, confirm the next Publish canary run succeeds end-to-end and that Deque.AxeCore.Playwright publishes at the new `4.11.3-alpha.N` (i.e. advances past `alpha.120`) on nuget.org, alongside Commons/Selenium at the same build number.
