### PR TITLE
ci: use pat to create the production github release

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
-      contents: write # this permission controls release creation
+      contents: read # checkout only; release creation is authenticated with secrets.PAT
     steps:     
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
           chmod +x ./node-github-release.sh
           ./node-github-release.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
           CIRCLE_PROJECT_USERNAME: ${{ github.repository_owner }}
           CIRCLE_PROJECT_REPONAME: ${{ github.event.repository.name }}
           GITHUB_RELEASE_TARGET: master


### PR DESCRIPTION
## Details

The `publish-github-release` job in `publish-production.yml` now authenticates `node-github-release.sh` with `secrets.PAT` instead of the auto-generated `secrets.GITHUB_TOKEN`, and its `GITHUB_TOKEN` permission drops from `contents: write` to `contents: read` since the only remaining consumer is `actions/checkout`.

**Why:** the v4.12.0 release failed ([run 28037077516](https://github.com/dequelabs/axe-core-nuget/actions/runs/28037077516)) with a 422 from the Releases API:

```
pre_receive Repository rule violations found
Cannot create ref due to creations being restricted.
...
Published releases must have a valid tag
```

The repository's "Tag Creation" ruleset restricts creation of `refs/tags/v*` and `refs/tags/*@v*` to members of the `dequelabs/ocarina-ci-users` team. `GITHUB_TOKEN` is not a member, so it could not create the tag backing the release, and GitHub then rejected the release for having no valid tag. NuGet publishing had already succeeded, so 4.12.0 shipped to nuget.org without a GitHub release — I created the release and its tag manually at `690ba31`.

`secrets.PAT` belongs to the `axe-core` machine account, which is an active member of `ocarina-ci-users`, so it carries the bypass this job needs. This mirrors what `create-release-candidate.yml` and `update-axe-core.yml` already do, following the same reasoning as #241.

No QA Required